### PR TITLE
그룹(가족) 생성 및 그룹별 초대코드 생성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set up application.properties
-        run: echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.properties
+      - name: Set up application.yml
+        run: echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.yml
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/src/main/java/com/codeit/donggrina/DonggrinaApplication.java
+++ b/src/main/java/com/codeit/donggrina/DonggrinaApplication.java
@@ -2,12 +2,14 @@ package com.codeit.donggrina;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DonggrinaApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(DonggrinaApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(DonggrinaApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/codeit/donggrina/DonggrinaApplication.java
+++ b/src/main/java/com/codeit/donggrina/DonggrinaApplication.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class DonggrinaApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(DonggrinaApplication.class, args);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(DonggrinaApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/codeit/donggrina/common/Timestamp.java
+++ b/src/main/java/com/codeit/donggrina/common/Timestamp.java
@@ -14,11 +14,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class Timestamp {
 
-  @CreatedDate
-  @Column(updatable = false)
-  private LocalDateTime createdAt;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
-  @LastModifiedDate
-  @Column
-  private LocalDateTime modifiedAt;
+    @LastModifiedDate
+    @Column
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/codeit/donggrina/common/Timestamp.java
+++ b/src/main/java/com/codeit/donggrina/common/Timestamp.java
@@ -1,0 +1,24 @@
+package com.codeit.donggrina.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamp {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column
+  private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/codeit/donggrina/common/api/ApiControllerAdvice.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ApiControllerAdvice.java
@@ -1,0 +1,46 @@
+package com.codeit.donggrina.common.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+  /**
+   * MethodArgumentNotValidException 발생 시, 유효성 검사 실패 응답을 반환합니다.
+   *
+   * @param e MethodArgumentNotValidException
+   * @return ErrorResponse
+   */
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ValidationErrorResponse validationErrorHandler(MethodArgumentNotValidException e) {
+    ValidationErrorResponse response = ValidationErrorResponse.builder()
+        .code(HttpStatus.BAD_REQUEST.value())
+        .message("잘못된 요청입니다.")
+        .build();
+    for (FieldError fieldError : e.getFieldErrors()) {
+      response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+    }
+    return response;
+  }
+
+  /**
+   * IllegalArgumentException 발생 시, 잘못된 요청에 대한 응답을 반환합니다.
+   *
+   * @param e IllegalArgumentException
+   * @return ErrorResponse
+   */
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ErrorResponse invalidRequestHandler(IllegalArgumentException e) {
+    return ErrorResponse.builder()
+        .code(HttpStatus.BAD_REQUEST.value())
+        .message(e.getMessage())
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/donggrina/common/api/ApiControllerAdvice.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ApiControllerAdvice.java
@@ -10,37 +10,37 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ApiControllerAdvice {
 
-  /**
-   * MethodArgumentNotValidException 발생 시, 유효성 검사 실패 응답을 반환합니다.
-   *
-   * @param e MethodArgumentNotValidException
-   * @return ErrorResponse
-   */
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ValidationErrorResponse validationErrorHandler(MethodArgumentNotValidException e) {
-    ValidationErrorResponse response = ValidationErrorResponse.builder()
-        .code(HttpStatus.BAD_REQUEST.value())
-        .message("잘못된 요청입니다.")
-        .build();
-    for (FieldError fieldError : e.getFieldErrors()) {
-      response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+    /**
+     * MethodArgumentNotValidException 발생 시, 유효성 검사 실패 응답을 반환합니다.
+     *
+     * @param e MethodArgumentNotValidException
+     * @return ErrorResponse
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ValidationErrorResponse validationErrorHandler(MethodArgumentNotValidException e) {
+        ValidationErrorResponse response = ValidationErrorResponse.builder()
+            .code(HttpStatus.BAD_REQUEST.value())
+            .message("잘못된 요청입니다.")
+            .build();
+        for (FieldError fieldError : e.getFieldErrors()) {
+            response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return response;
     }
-    return response;
-  }
 
-  /**
-   * IllegalArgumentException 발생 시, 잘못된 요청에 대한 응답을 반환합니다.
-   *
-   * @param e IllegalArgumentException
-   * @return ErrorResponse
-   */
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @ExceptionHandler(IllegalArgumentException.class)
-  public ErrorResponse invalidRequestHandler(IllegalArgumentException e) {
-    return ErrorResponse.builder()
-        .code(HttpStatus.BAD_REQUEST.value())
-        .message(e.getMessage())
-        .build();
-  }
+    /**
+     * IllegalArgumentException 발생 시, 잘못된 요청에 대한 응답을 반환합니다.
+     *
+     * @param e IllegalArgumentException
+     * @return ErrorResponse
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResponse invalidRequestHandler(IllegalArgumentException e) {
+        return ErrorResponse.builder()
+            .code(HttpStatus.BAD_REQUEST.value())
+            .message(e.getMessage())
+            .build();
+    }
 }

--- a/src/main/java/com/codeit/donggrina/common/api/ApiResponse.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ApiResponse.java
@@ -9,7 +9,7 @@ public record ApiResponse<T>(
     T data
 ) {
 
-  public static <T> ApiResponse<T> of(int code, String message, T data) {
-    return new ApiResponse<>(code, message, data);
-  }
+    public static <T> ApiResponse<T> of(int code, String message, T data) {
+        return new ApiResponse<>(code, message, data);
+    }
 }

--- a/src/main/java/com/codeit/donggrina/common/api/ApiResponse.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ApiResponse.java
@@ -1,0 +1,15 @@
+package com.codeit.donggrina.common.api;
+
+import lombok.Builder;
+
+@Builder
+public record ApiResponse<T>(
+    int code,
+    String message,
+    T data
+) {
+
+  public static <T> ApiResponse<T> of(int code, String message, T data) {
+    return new ApiResponse<>(code, message, data);
+  }
+}

--- a/src/main/java/com/codeit/donggrina/common/api/ErrorResponse.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ErrorResponse.java
@@ -1,0 +1,8 @@
+package com.codeit.donggrina.common.api;
+
+import lombok.Builder;
+
+@Builder
+public record ErrorResponse(int code, String message) {
+
+}

--- a/src/main/java/com/codeit/donggrina/common/api/ValidationErrorResponse.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ValidationErrorResponse.java
@@ -6,14 +6,14 @@ import lombok.Builder;
 
 public record ValidationErrorResponse(int code, String message, Map<String, String> validation) {
 
-  @Builder
-  public ValidationErrorResponse(int code, String message, Map<String, String> validation) {
-    this.code = code;
-    this.message = message;
-    this.validation = validation != null ? validation : new HashMap<>();
-  }
+    @Builder
+    public ValidationErrorResponse(int code, String message, Map<String, String> validation) {
+        this.code = code;
+        this.message = message;
+        this.validation = validation != null ? validation : new HashMap<>();
+    }
 
-  public void addValidation(String fieldName, String errorMessage) {
-    this.validation.put(fieldName, errorMessage);
-  }
+    public void addValidation(String fieldName, String errorMessage) {
+        this.validation.put(fieldName, errorMessage);
+    }
 }

--- a/src/main/java/com/codeit/donggrina/common/api/ValidationErrorResponse.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ValidationErrorResponse.java
@@ -1,0 +1,19 @@
+package com.codeit.donggrina.common.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+
+public record ValidationErrorResponse(int code, String message, Map<String, String> validation) {
+
+  @Builder
+  public ValidationErrorResponse(int code, String message, Map<String, String> validation) {
+    this.code = code;
+    this.message = message;
+    this.validation = validation != null ? validation : new HashMap<>();
+  }
+
+  public void addValidation(String fieldName, String errorMessage) {
+    this.validation.put(fieldName, errorMessage);
+  }
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -14,15 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class GroupController {
 
-  private final GroupService groupService;
+    private final GroupService groupService;
 
-  @PostMapping("/my/groups")
-  public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request) {
-    Long result = groupService.append(request);
-    return ApiResponse.<Long>builder()
-        .code(HttpStatus.OK.value())
-        .message("가족(그룹) 등록 성공")
-        .data(result)
-        .build();
-  }
+    @PostMapping("/my/groups")
+    public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request) {
+        Long result = groupService.append(request);
+        return ApiResponse.<Long>builder()
+            .code(HttpStatus.OK.value())
+            .message("가족(그룹) 등록 성공")
+            .data(result)
+            .build();
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -1,0 +1,28 @@
+package com.codeit.donggrina.domain.group.controller;
+
+import com.codeit.donggrina.common.api.ApiResponse;
+import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
+import com.codeit.donggrina.domain.group.service.GroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GroupController {
+
+  private final GroupService groupService;
+
+  @PostMapping("/my/groups")
+  public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request) {
+    Long result = groupService.append(request);
+    return ApiResponse.<Long>builder()
+        .code(HttpStatus.OK.value())
+        .message("가족(그룹) 등록 성공")
+        .data(result)
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupAppendRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupAppendRequest.java
@@ -1,0 +1,12 @@
+package com.codeit.donggrina.domain.group.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record GroupAppendRequest(
+    @NotBlank(message = "가족(그룹) 이름 입력을 다시 확인해주세요.") String name,
+    @NotBlank(message = "가족(그룹) 생성자 이름 입력을 다시 확인해주세요.") String creatorName
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
@@ -1,0 +1,37 @@
+package com.codeit.donggrina.domain.group.entity;
+
+import com.codeit.donggrina.common.Timestamp;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "families")
+public class Group extends Timestamp {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(nullable = false)
+  private String name;
+  @Column(nullable = false)
+  private String code;
+  @Column(nullable = false)
+  private String creatorName;
+
+  @Builder
+  private Group(String name, String code, String creatorName) {
+    this.name = name;
+    this.code = code;
+    this.creatorName = creatorName;
+  }
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
@@ -18,20 +18,20 @@ import lombok.NoArgsConstructor;
 @Table(name = "families")
 public class Group extends Timestamp {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
-  @Column(nullable = false)
-  private String name;
-  @Column(nullable = false)
-  private String code;
-  @Column(nullable = false)
-  private String creatorName;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private String code;
+    @Column(nullable = false)
+    private String creatorName;
 
-  @Builder
-  private Group(String name, String code, String creatorName) {
-    this.name = name;
-    this.code = code;
-    this.creatorName = creatorName;
-  }
+    @Builder
+    private Group(String name, String code, String creatorName) {
+        this.name = name;
+        this.code = code;
+        this.creatorName = creatorName;
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
     Optional<Group> findByName(String name);
+
+    Optional<Group> findByCode(String code);
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
@@ -1,0 +1,10 @@
+package com.codeit.donggrina.domain.group.repository;
+
+import com.codeit.donggrina.domain.group.entity.Group;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+  Optional<Group> findByName(String name);
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
-  Optional<Group> findByName(String name);
+    Optional<Group> findByName(String name);
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -1,5 +1,6 @@
 package com.codeit.donggrina.domain.group.service;
 
+
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
@@ -14,8 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupService {
 
-    private final static int INVITATION_CODE_LENGTH = 8;
-    private final static String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private final GroupRepository groupRepository;
 
     @Transactional
@@ -35,10 +34,13 @@ public class GroupService {
     }
 
     private String generateRandomInvitationCode() {
+        int codeLength = 8;
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
         Random random = new Random();
-        return IntStream.range(0, INVITATION_CODE_LENGTH)
-            .map(i -> random.nextInt(CHARACTERS.length()))
-            .mapToObj(CHARACTERS::charAt)
+        return IntStream.range(0, codeLength)
+            .map(i -> random.nextInt(characters.length()))
+            .mapToObj(characters::charAt)
             .map(Object::toString)
             .collect(Collectors.joining());
     }

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -14,32 +14,32 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupService {
 
-  private final static int INVITATION_CODE_LENGTH = 8;
-  private final static String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  private final GroupRepository groupRepository;
+    private final static int INVITATION_CODE_LENGTH = 8;
+    private final static String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private final GroupRepository groupRepository;
 
-  @Transactional
-  public Long append(GroupAppendRequest request) {
-    String name = request.name();
-    groupRepository.findByName(name).ifPresent(group -> {
-      throw new IllegalArgumentException("이미 존재하는 그룹 이름입니다.");
-    });
-    String creatorName = request.creatorName();
-    String code = generateRandomInvitationCode();
-    Group group = Group.builder()
-        .name(name)
-        .code(code)
-        .creatorName(creatorName)
-        .build();
-    return groupRepository.save(group).getId();
-  }
+    @Transactional
+    public Long append(GroupAppendRequest request) {
+        String name = request.name();
+        groupRepository.findByName(name).ifPresent(group -> {
+            throw new IllegalArgumentException("이미 존재하는 그룹 이름입니다.");
+        });
+        String creatorName = request.creatorName();
+        String code = generateRandomInvitationCode();
+        Group group = Group.builder()
+            .name(name)
+            .code(code)
+            .creatorName(creatorName)
+            .build();
+        return groupRepository.save(group).getId();
+    }
 
-  private String generateRandomInvitationCode() {
-    Random random = new Random();
-    return IntStream.range(0, INVITATION_CODE_LENGTH)
-        .map(i -> random.nextInt(CHARACTERS.length()))
-        .mapToObj(CHARACTERS::charAt)
-        .map(Object::toString)
-        .collect(Collectors.joining());
-  }
+    private String generateRandomInvitationCode() {
+        Random random = new Random();
+        return IntStream.range(0, INVITATION_CODE_LENGTH)
+            .map(i -> random.nextInt(CHARACTERS.length()))
+            .mapToObj(CHARACTERS::charAt)
+            .map(Object::toString)
+            .collect(Collectors.joining());
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -1,6 +1,5 @@
 package com.codeit.donggrina.domain.group.service;
 
-
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
@@ -36,12 +35,19 @@ public class GroupService {
     private String generateRandomInvitationCode() {
         int codeLength = 8;
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
         Random random = new Random();
-        return IntStream.range(0, codeLength)
-            .map(i -> random.nextInt(characters.length()))
-            .mapToObj(characters::charAt)
-            .map(Object::toString)
-            .collect(Collectors.joining());
+
+        while (true) {
+            String code = IntStream.range(0, codeLength)
+                .map(i -> random.nextInt(characters.length()))
+                .mapToObj(characters::charAt)
+                .map(Object::toString)
+                .collect(Collectors.joining());
+
+            // 코드가 이미 존재하는지 확인하고 존재하지 않으면 코드를 반환, 존재하면 while문을 다시 타면서 코드 다시 생성
+            if (groupRepository.findByCode(code).isEmpty()) {
+                return code;
+            }
+        }
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -1,0 +1,45 @@
+package com.codeit.donggrina.domain.group.service;
+
+import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
+import com.codeit.donggrina.domain.group.entity.Group;
+import com.codeit.donggrina.domain.group.repository.GroupRepository;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+
+  private final static int INVITATION_CODE_LENGTH = 8;
+  private final static String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  private final GroupRepository groupRepository;
+
+  @Transactional
+  public Long append(GroupAppendRequest request) {
+    String name = request.name();
+    groupRepository.findByName(name).ifPresent(group -> {
+      throw new IllegalArgumentException("이미 존재하는 그룹 이름입니다.");
+    });
+    String creatorName = request.creatorName();
+    String code = generateRandomInvitationCode();
+    Group group = Group.builder()
+        .name(name)
+        .code(code)
+        .creatorName(creatorName)
+        .build();
+    return groupRepository.save(group).getId();
+  }
+
+  private String generateRandomInvitationCode() {
+    Random random = new Random();
+    return IntStream.range(0, INVITATION_CODE_LENGTH)
+        .map(i -> random.nextInt(CHARACTERS.length()))
+        .mapToObj(CHARACTERS::charAt)
+        .map(Object::toString)
+        .collect(Collectors.joining());
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,3 +15,25 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  jwt:
+    secret: anmslkfnagkljasnkdkmaslmglnmalsmdlkmaskngnasnmd123125tklnmekldgf
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${DONGGRINA_KAKAO_CLIENT_ID}
+            client-secret: ${DONGGRINA_KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/members/login/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+              - profile_image
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
## Issue Link
close #3

## To Reviewers
### 1. 그룹(가족) 생성할 수 있도록 POST 요청 API 생성
- 중복된 이름의 그룹(가족)은 생성 불가
- 그룹(가족) 생성 시 생성자의 이름을 같이 저장
    - 추후에 방장만 새로운 멤버 추가하거나 기존 멤버 강퇴하는 기능 고려
    - 이 부분 어떻게 생각하시는지 댓글 남겨주시면 감사하겠습니다.

### 2. 공통으로 사용할 만한 클래스 생성
- `ValidationErrorResponse` 클래스는 클라이언트에서 입력할 때 발생하는 유효성 검사에 대한 예외를 처리
- `ErrorResponse` 클래스는 비즈니스 로직에서 발생하는 예외를 처리
- 데이터 저장할 때 자동으로 생성시간, 수정시간을 추적해주기 위해 `Timestamp` 클래스 생성
- 예외가 터지는 걸 모아서 처리할 `ApiControllerAdvice` 클래스 생성
- API 공통 응답을 처리할 `ApiResponse` 클래스 생성
<br>
공통으로 사용하는 클래스들에 대해서 의견 있으시면 반영해주시거나 댓글 남겨주시면 감사하겠습니다.

## Reference
