### PR TITLE
그룹 생성 Refactoring, 그룹 멤버 초대 Feature

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -4,8 +4,11 @@ import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
 import com.codeit.donggrina.domain.group.dto.request.GroupMemberAddRequest;
 import com.codeit.donggrina.domain.group.service.GroupService;
+import com.codeit.donggrina.domain.member.dto.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,8 +22,10 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping("/my/groups")
-    public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request) {
-        Long result = groupService.append(request);
+    public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request,
+        @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getMemberId();
+        Long result = groupService.append(request, userId);
         return ApiResponse.<Long>builder()
             .code(HttpStatus.OK.value())
             .message("가족(그룹) 등록 성공")
@@ -28,12 +33,11 @@ public class GroupController {
             .build();
     }
 
-    @PostMapping("/my/groups/members/{groupId}")
-    public ApiResponse<Void> addMember(
-        @PathVariable Long groupId,
-        @RequestBody @Validated GroupMemberAddRequest request
-    ) {
-        groupService.addMember(groupId, request);
+    @PostMapping("/my/groups/members")
+    public ApiResponse<Void> addMember(@RequestBody @Validated GroupMemberAddRequest request,
+        @AuthenticationPrincipal CustomOAuth2User user) {
+        Long userId = user.getMemberId();
+        groupService.addMember(request, userId);
         return ApiResponse.<Void>builder()
             .code(HttpStatus.OK.value())
             .message("가족(그룹) 멤버 추가 성공")

--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -2,10 +2,12 @@ package com.codeit.donggrina.domain.group.controller;
 
 import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
+import com.codeit.donggrina.domain.group.dto.request.GroupMemberAddRequest;
 import com.codeit.donggrina.domain.group.service.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +25,19 @@ public class GroupController {
             .code(HttpStatus.OK.value())
             .message("가족(그룹) 등록 성공")
             .data(result)
+            .build();
+    }
+
+    @PostMapping("/my/groups/members/{groupId}")
+    public ApiResponse<Void> addMember(
+        @PathVariable Long groupId,
+        @RequestBody @Validated GroupMemberAddRequest request
+    ) {
+        groupService.addMember(groupId, request);
+        return ApiResponse.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .message("가족(그룹) 멤버 추가 성공")
+            .data(null)
             .build();
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupAppendRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupAppendRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 @Builder
 public record GroupAppendRequest(
     @NotBlank(message = "가족(그룹) 이름 입력을 다시 확인해주세요.") String name,
-    @NotBlank(message = "가족(그룹) 생성자 이름 입력을 다시 확인해주세요.") String creatorName
+    @NotBlank(message = "닉네임 입력을 다시 확인해주세요.") String nickname
 ) {
 
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupMemberAddRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupMemberAddRequest.java
@@ -1,0 +1,11 @@
+package com.codeit.donggrina.domain.group.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record GroupMemberAddRequest(
+    @NotBlank(message = "초대 코드 입력을 다시 확인해주세요.") String code
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupMemberAddRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/dto/request/GroupMemberAddRequest.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 
 @Builder
 public record GroupMemberAddRequest(
-    @NotBlank(message = "초대 코드 입력을 다시 확인해주세요.") String code
+    @NotBlank(message = "초대 코드 입력을 다시 확인해주세요.") String code,
+    @NotBlank(message = "그룹에서 사용할 닉네임을 다시 입력해주세요.") String nickname
 ) {
 
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
@@ -1,12 +1,18 @@
 package com.codeit.donggrina.domain.group.entity;
 
 import com.codeit.donggrina.common.Timestamp;
+import com.codeit.donggrina.domain.member.entity.Member;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,10 +34,18 @@ public class Group extends Timestamp {
     @Column(nullable = false)
     private String creatorName;
 
+    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Member> members = new ArrayList<>();
+
     @Builder
     private Group(String name, String code, String creatorName) {
         this.name = name;
         this.code = code;
         this.creatorName = creatorName;
+    }
+
+    public void addMember(Member member) {
+        members.add(member);
+        member.joinGroup(this);
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
@@ -32,16 +32,16 @@ public class Group extends Timestamp {
     @Column(nullable = false)
     private String code;
     @Column(nullable = false)
-    private String creatorName;
+    private String creator;
 
     @OneToMany(mappedBy = "group", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Member> members = new ArrayList<>();
 
     @Builder
-    private Group(String name, String code, String creatorName) {
+    private Group(String name, String code, String creator) {
         this.name = name;
         this.code = code;
-        this.creatorName = creatorName;
+        this.creator = creator;
     }
 
     public void addMember(Member member) {

--- a/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "families")
+@Table(name = "clusters")
 public class Group extends Timestamp {
 
     @Id

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -1,8 +1,12 @@
 package com.codeit.donggrina.domain.group.service;
 
+import com.codeit.donggrina.common.util.SecurityUtil;
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
+import com.codeit.donggrina.domain.group.dto.request.GroupMemberAddRequest;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
+import com.codeit.donggrina.domain.member.entity.Member;
+import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -15,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupService {
 
     private final GroupRepository groupRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public Long append(GroupAppendRequest request) {
@@ -30,6 +35,21 @@ public class GroupService {
             .creatorName(creatorName)
             .build();
         return groupRepository.save(group).getId();
+    }
+
+    @Transactional
+    public void addMember(Long groupId, GroupMemberAddRequest request) {
+        // 그룹 식별자로 그룹을 조회한 후에 사용자가 입력한 코드가 그룹의 코드와 일치하는지 확인합니다.
+        String code = request.code();
+        Group group = groupRepository.findById(groupId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+        if (!group.getCode().equals(code)) {
+            throw new IllegalArgumentException("초대 코드가 일치하지 않습니다.");
+        }
+        // 현재 가족에 들어가기 위해 로그인 한 사용자(초대받은 사람)를 그룹에 추가해줍니다.
+        Member member = memberRepository.findById(SecurityUtil.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        group.addMember(member);
     }
 
     private String generateRandomInvitationCode() {

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -22,6 +22,7 @@ public class Member {
     private String username;
     private String name;
     private String role;
+    private String nickname; // 그룹 내에서 사용할 닉네임
     @ManyToOne
     @JoinColumn(name = "group_id")
     private Group group;
@@ -36,5 +37,9 @@ public class Member {
 
     public void joinGroup(Group group) {
         this.group = group;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -1,10 +1,12 @@
 package com.codeit.donggrina.domain.member.entity;
 
+import com.codeit.donggrina.domain.group.entity.Group;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,9 @@ public class Member {
     private String username;
     private String name;
     private String role;
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
 
     @Builder
     private Member(Long id, String username, String name, String role) {
@@ -27,5 +32,9 @@ public class Member {
         this.username = username;
         this.name = name;
         this.role = role;
+    }
+
+    public void joinGroup(Group group) {
+        this.group = group;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,9 +13,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-      format_sql: true
     properties:
       hibernate:
+        format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
   jwt:
     secret: anmslkfnagkljasnkdkmaslmglnmalsmdlkmaskngnasnmd123125tklnmekldgf


### PR DESCRIPTION
## Issue Link
close #8 

## To Reviewers
### 그룹 생성 Refactoring
- 그룹 생성 시 별도의 생성자 이름을 클라이언트로부터 받지 않습니다.
- 그룹 생성 시 로그인 한 사용자의 고유한 username을 데이터베이스에 함께 저장합니다.

### 그룹 멤버 초대 Feature
- 초대 받은 사람이 초대 코드를 입력하면 초대 코드로 데이터베이스를 조회한 후에 일치하는 그룹에 매핑해줍니다.
- note 주석 읽어봐주시고 의견 남겨주시면 감사하겠습니다.

### 기타
- application-local.yml 에서 format_sql 위치가 잘못된 것을 수정했습니다.
- Group 엔티티가 매핑된 데이터베이스 테이블의 이름을 families -> clusters 로 수정했습니다.

## Reference
