### PR TITLE
사용자 프로필 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ http
 
 ### application-prod.yml
 /src/main/resources/application-prod.yml
+
+## 환경변수 파일
+.env

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/entity/ProfileImage.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/entity/ProfileImage.java
@@ -1,0 +1,28 @@
+package com.codeit.donggrina.domain.ProfileImage.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String url;
+
+    @Builder
+    private ProfileImage(Long id, String name, String url) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.codeit.donggrina.domain.member.controller;
+
+import com.codeit.donggrina.common.api.ApiResponse;
+import com.codeit.donggrina.domain.member.dto.response.MyProfileGetResponse;
+import com.codeit.donggrina.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my/profiles")
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/{memberId}")
+    public ApiResponse<MyProfileGetResponse> getMyProfile(@PathVariable("memberId") Long memberId) {
+        return ApiResponse.<MyProfileGetResponse>builder()
+            .code(HttpStatus.OK.value())
+            .message("프로필 조회 성공")
+            .data(memberService.getMyProfile(memberId))
+            .build();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/member/dto/response/MyProfileGetResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/dto/response/MyProfileGetResponse.java
@@ -1,0 +1,9 @@
+package com.codeit.donggrina.domain.member.dto.response;
+
+public record MyProfileGetResponse(
+    Long id,
+    String name,
+    String profileImageUrl
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -34,14 +34,13 @@ public class Member {
 
     @Builder
     private Member(Long id, String username, String name, String role, ProfileImage profileImage,
-        String nickname, Group group) {
+        String nickname) {
         this.id = id;
         this.username = username;
         this.name = name;
         this.role = role;
         this.profileImage = profileImage;
         this.nickname = nickname;
-        this.group = group;
     }
 
     public void joinGroup(Group group) {

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -1,10 +1,13 @@
 package com.codeit.donggrina.domain.member.entity;
 
+import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,12 +23,16 @@ public class Member {
     private String username;
     private String name;
     private String role;
+    @OneToOne
+    @JoinColumn(name = "profile_image_id")
+    private ProfileImage profileImage;
 
     @Builder
-    private Member(Long id, String username, String name, String role) {
+    private Member(Long id, String username, String name, String role, ProfileImage profileImage) {
         this.id = id;
         this.username = username;
         this.name = name;
         this.role = role;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/repository/MemberRepository.java
@@ -1,9 +1,19 @@
 package com.codeit.donggrina.domain.member.repository;
 
+import com.codeit.donggrina.domain.member.dto.response.MyProfileGetResponse;
 import com.codeit.donggrina.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByUsername(String username);
+
+    @Query("select new com.codeit.donggrina.domain.member.dto.response"
+        + ".MyProfileGetResponse(m.id, m.name, pi.url)"
+        + " from Member m join ProfileImage pi on m.profileImage.id = pi.id where m.id=:memberId")
+    Optional<MyProfileGetResponse> findMyProfileById(Long memberId);
+
+
 }

--- a/src/main/java/com/codeit/donggrina/domain/member/service/MemberService.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/service/MemberService.java
@@ -1,0 +1,16 @@
+package com.codeit.donggrina.domain.member.service;
+
+import com.codeit.donggrina.domain.member.dto.response.MyProfileGetResponse;
+import com.codeit.donggrina.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MyProfileGetResponse getMyProfile(Long memberId) {
+        return memberRepository.findMyProfileById(memberId).orElseThrow(RuntimeException::new);
+    }
+}


### PR DESCRIPTION
## Issue Link
close #6

## To Reviewers
사용자 프로필 조회를 위한 로직을 작성했습니다.
조회 시 jpa context에 영속되는 과정을 없애고자 jpa projections를 이용해 한번에 조회하도록 하였습니다.

환경변수 파일을 gitignore에 추가했습니다.
예외처리는 나중에 다시 맞춰야 될 것 같아서 런타임으로 해뒀습니다.

## Reference
