### PR TITLE
그룹에서 멤버 삭제, 그룹 삭제 버그 수정

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -72,4 +72,18 @@ public class GroupController {
             .message("가족(그룹) 삭제 성공")
             .build();
     }
+
+    @PostMapping("/my/groups/{groupId}/members/{targetId}")
+    public ApiResponse<Void> deleteMember(
+        @PathVariable Long targetId,
+        @PathVariable Long groupId,
+        @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        Long userId = user.getMemberId();
+        groupService.deleteMember(targetId, groupId, userId);
+        return ApiResponse.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .message("가족(그룹) 멤버 삭제 성공")
+            .build();
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/entity/Group.java
@@ -2,7 +2,6 @@ package com.codeit.donggrina.domain.group.entity;
 
 import com.codeit.donggrina.common.Timestamp;
 import com.codeit.donggrina.domain.member.entity.Member;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -34,7 +33,7 @@ public class Group extends Timestamp {
     @Column(nullable = false)
     private String creator;
 
-    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
     private final List<Member> members = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -94,7 +94,7 @@ public class GroupService {
             throw new IllegalArgumentException("그룹에 멤버가 존재하면 그룹을 삭제할 수 없습니다.");
         }
         // 외래키 제약 조건 때문에 멤버와 그룹을 먼저 연관관계를 끊어주고 그룹을 삭제합니다.
-        group.getMembers().forEach(Member::leaveGroup);
+        member.leaveGroup();
         groupRepository.delete(group);
     }
 

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -93,7 +93,27 @@ public class GroupService {
         if (!group.isDeletable()) {
             throw new IllegalArgumentException("그룹에 멤버가 존재하면 그룹을 삭제할 수 없습니다.");
         }
+        // 외래키 제약 조건 때문에 멤버와 그룹을 먼저 연관관계를 끊어주고 그룹을 삭제합니다.
+        group.getMembers().forEach(Member::leaveGroup);
         groupRepository.delete(group);
+    }
+
+    @Transactional
+    public void deleteMember(Long targetId, Long groupId, Long userId) {
+        // 그룹과 로그인 유저, 삭제 대상 유저를 조회합니다.
+        Group group = groupRepository.findById(groupId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+        Member loginMember = memberRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Member targetMember = memberRepository.findById(targetId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // 방장이 아니라면 멤버를 삭제할 수 없습니다.
+        if (!loginMember.getUsername().equals(group.getCreator())) {
+            throw new IllegalArgumentException("그룹 멤버를 삭제할 권한이 없습니다.");
+        }
+        // 그룹과 멤버의 연관관계를 끊어줌으로써 그룹에서 멤버를 삭제합니다.
+        targetMember.leaveGroup();
     }
 
     private String generateRandomInvitationCode() {

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -47,6 +47,10 @@ public class Member {
         this.group = group;
     }
 
+    public void leaveGroup() {
+        this.group = null;
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }


### PR DESCRIPTION
## Issue Link
close #17 

## To Reviewers
### 그룹에서 멤버 삭제
- 그룹에서 멤버를 삭제합니다.
- 실제로 멤버를 데이터베이스에서 삭제하는 것은 아니고, 그룹과 멤버 사이의 연관관계를 끊어줍니다.

### 그룹 삭제 버그 수정
- 그룹과 멤버 연관관계의 cascade 속성을 없애줌으로써 외래키 제약 조건을 해결해야 했습니다. 
    - 생명주기가 다르다고 판단해서 없애주었습니다.
- 그룹을 삭제하기 전 방장과 그룹 사이의 연관관계도 null 로 만들어 준 후에 그룹을 삭제합니다.

## Reference
