### PR TITLE
그룹 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/codeit/donggrina/common/config/QuerydslConfig.java
+++ b/src/main/java/com/codeit/donggrina/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.codeit.donggrina.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -4,6 +4,7 @@ import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
 import com.codeit.donggrina.domain.group.dto.request.GroupMemberAddRequest;
 import com.codeit.donggrina.domain.group.dto.request.GroupUpdateRequest;
+import com.codeit.donggrina.domain.group.dto.response.GroupDetailResponse;
 import com.codeit.donggrina.domain.group.service.GroupService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,6 +24,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class GroupController {
 
     private final GroupService groupService;
+
+    @GetMapping("/my/groups/{groupId}")
+    public ApiResponse<GroupDetailResponse> getDetail(@PathVariable Long groupId) {
+        GroupDetailResponse result = groupService.getDetail(groupId);
+        return ApiResponse.<GroupDetailResponse>builder()
+            .code(HttpStatus.OK.value())
+            .message("가족(그룹) 상세 조회 성공")
+            .data(result)
+            .build();
+    }
 
     @PostMapping("/my/groups")
     public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request,

--- a/src/main/java/com/codeit/donggrina/domain/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/dto/response/GroupDetailResponse.java
@@ -1,0 +1,16 @@
+package com.codeit.donggrina.domain.group.dto.response;
+
+import com.codeit.donggrina.domain.member.dto.response.MyProfileGetResponse;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GroupDetailResponse(
+    Long id,
+    String name,
+    String invitationCode,
+    List<MyProfileGetResponse> members,
+    Long membersCount
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/repository/CustomGroupRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/CustomGroupRepository.java
@@ -1,0 +1,8 @@
+package com.codeit.donggrina.domain.group.repository;
+
+import com.codeit.donggrina.domain.group.dto.response.GroupDetailResponse;
+
+public interface CustomGroupRepository {
+
+    GroupDetailResponse findGroupDetail(Long groupId);
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/repository/CustomGroupRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/CustomGroupRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.codeit.donggrina.domain.group.repository;
+
+import static com.codeit.donggrina.domain.ProfileImage.entity.QProfileImage.profileImage;
+import static com.codeit.donggrina.domain.member.entity.QMember.member;
+
+import com.codeit.donggrina.domain.group.dto.response.GroupDetailResponse;
+import com.codeit.donggrina.domain.group.entity.Group;
+import com.codeit.donggrina.domain.group.entity.QGroup;
+import com.codeit.donggrina.domain.member.dto.response.MyProfileGetResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomGroupRepositoryImpl implements CustomGroupRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public GroupDetailResponse findGroupDetail(Long groupId) {
+        // Group 정보와 Member, ProfileImage 정보를 함께 조회
+        Group group = queryFactory
+            .selectFrom(QGroup.group)
+            .leftJoin(QGroup.group.members, member).fetchJoin()
+            .leftJoin(member.profileImage, profileImage).fetchJoin()
+            .where(QGroup.group.id.eq(groupId))
+            .distinct()
+            .fetchOne();
+
+        if (group == null) {
+            throw new IllegalArgumentException("존재하지 않는 그룹입니다.");
+        }
+
+        // 멤버 수 카운트 쿼리
+        Long membersCount = queryFactory
+            .select(member.count())
+            .from(member)
+            .where(member.group.id.eq(groupId))
+            .fetchOne();
+
+        // MyProfileGetResponse 기반 members 생성
+        List<MyProfileGetResponse> members = group.getMembers()
+            .stream()
+            .map(MyProfileGetResponse::from)
+            .collect(Collectors.toList());
+
+        return GroupDetailResponse
+            .builder()
+            .id(group.getId())
+            .name(group.getName())
+            .invitationCode(group.getCode())
+            .members(members)
+            .membersCount(membersCount)
+            .build();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/GroupRepository.java
@@ -4,7 +4,7 @@ import com.codeit.donggrina.domain.group.entity.Group;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GroupRepository extends JpaRepository<Group, Long> {
+public interface GroupRepository extends JpaRepository<Group, Long>, CustomGroupRepository {
 
     Optional<Group> findByName(String name);
 

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -3,6 +3,7 @@ package com.codeit.donggrina.domain.group.service;
 import com.codeit.donggrina.domain.group.dto.request.GroupAppendRequest;
 import com.codeit.donggrina.domain.group.dto.request.GroupMemberAddRequest;
 import com.codeit.donggrina.domain.group.dto.request.GroupUpdateRequest;
+import com.codeit.donggrina.domain.group.dto.response.GroupDetailResponse;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.member.entity.Member;
@@ -20,6 +21,11 @@ public class GroupService {
 
     private final GroupRepository groupRepository;
     private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public GroupDetailResponse getDetail(Long groupId) {
+        return groupRepository.findGroupDetail(groupId);
+    }
 
     @Transactional
     public Long append(GroupAppendRequest request, Long userId) {

--- a/src/main/java/com/codeit/donggrina/domain/member/dto/response/MyProfileGetResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/dto/response/MyProfileGetResponse.java
@@ -1,9 +1,21 @@
 package com.codeit.donggrina.domain.member.dto.response;
 
+import com.codeit.donggrina.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
 public record MyProfileGetResponse(
     Long id,
     String name,
+    String nickname,
     String profileImageUrl
 ) {
-
+    public static MyProfileGetResponse from(Member member) {
+        return MyProfileGetResponse.builder()
+            .id(member.getId())
+            .name(member.getName())
+            .nickname(member.getNickname())
+            .profileImageUrl(member.getProfileImage().getUrl())
+            .build();
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
 
     @Query("select new com.codeit.donggrina.domain.member.dto.response"
-        + ".MyProfileGetResponse(m.id, m.name, pi.url)"
+        + ".MyProfileGetResponse(m.id, m.name, m.nickname, pi.url)"
         + " from Member m join ProfileImage pi on m.profileImage.id = pi.id where m.id=:memberId")
     Optional<MyProfileGetResponse> findMyProfileById(Long memberId);
 


### PR DESCRIPTION
## Issue Link
close #20 

## To Reviewers
### 새롭게 추가된 부분
- Querydsl 사용하기 위해 설정 추가했습니다.
- 그룹 상세 조회 기능 구현했습니다.
    - 총 2개의 쿼리로 조회가 가능합니다.
    - 그룹 조회 시 멤버와 프로필 이미지를 fetch join 으로 함께 조회합니다.
    - 멤버의 카운트를 얻기 위해 별도의 카운트 쿼리를 날립니다.

### 변경된 부분
- 민우님 코드에서 변경된 부분입니다.
- `GroupDetailResponse` 클래스에서 `List<MyProfileGetResponse` 를 사용함에 따라 클라이언트가 필요할만한 필드를 `MyProfileGetResponse` 클래스에 추가했습니다.
- `MyProfileGetResponse` 클래스가 변경됨에 따라 `MemberRepository` 인터페이스에 있었던 쿼리에 변경이 있습니다.

## Reference
