### PR TITLE
카카오 로그인 후 이미지 저장

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/member/dto/response/KakaoResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/dto/response/KakaoResponse.java
@@ -19,4 +19,14 @@ public class KakaoResponse {
         Map<String, String> properties = (Map<String, String>) attribute.get("properties");
         return properties.get("nickname");
     }
+
+    public String getProfileImageUrl(){
+        Map<String, String> properties = (Map<String, String>) attribute.get("properties");
+        return properties.getOrDefault("profile_image_url", null);
+    }
+
+    public boolean hasProfileImageUrl() {
+        Map<String, String> properties = (Map<String, String>) attribute.get("properties");
+        return properties.containsKey("profile_image_url");
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.codeit.donggrina.domain.member.entity;
 
 import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
 import com.codeit.donggrina.domain.group.entity.Group;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,7 +25,7 @@ public class Member {
     private String username;
     private String name;
     private String role;
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
     private String nickname; // 그룹 내에서 사용할 닉네임

--- a/src/main/java/com/codeit/donggrina/domain/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/service/CustomOAuth2UserService.java
@@ -1,5 +1,7 @@
 package com.codeit.donggrina.domain.member.service;
 
+import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
+import com.codeit.donggrina.domain.ProfileImage.repository.ProfileImageRepository;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import com.codeit.donggrina.domain.member.dto.response.KakaoResponse;
 import com.codeit.donggrina.domain.member.dto.request.MemberSecurityDto;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final ProfileImageRepository profileImageRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -37,9 +40,19 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         Optional<Member> foundMemberOptional = memberRepository.findByUsername(username);
         MemberSecurityDto memberSecurityDto = null;
         if(foundMemberOptional.isEmpty()) {
+            ProfileImage profileImage = null;
+
+            if(kakaoResponse.hasProfileImageUrl()) {
+                profileImage = ProfileImage.builder()
+                    .name("kakao_profile_image")
+                    .url(kakaoResponse.getProfileImageUrl())
+                    .build();
+            }
+
             Member member = Member.builder()
                 .username(username)
                 .name(kakaoResponse.getName())
+                .profileImage(profileImage)
                 .role("ROLE_USER")
                 .build();
 


### PR DESCRIPTION
## Issue Link
close #50

## To Reviewers
카카오 로그인 후 이미지 저장되도록 로직을 추가했습니다.
카카오 로그인 시 프로필 사진 동의 여부에 따라 이미지를 추가하는 로직을 추가했습니다.
사용자가 프로필 사진을 공유 비동의 할 경우 기본이미지를 저장해줘야 되는데 이를 어떻게 하면 좋을까요?

## Reference
