### PR TITLE
성장기록 수정 기능

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -2,11 +2,14 @@ package com.codeit.donggrina.domain.growth_history.controller;
 
 import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
+import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
 import com.codeit.donggrina.domain.growth_history.service.GrowthHistoryService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,6 +30,20 @@ public class GrowthHistoryController {
             .code(200)
             .message("성장기록 추가 성공")
             .data(result)
+            .build();
+    }
+
+    @PutMapping("/growth/{growthId}")
+    public ApiResponse<Void> update(
+        @PathVariable Long growthId,
+        @RequestBody GrowthHistoryUpdateRequest request,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        growthHistoryService.update(memberId, growthId, request);
+        return ApiResponse.<Void>builder()
+            .code(200)
+            .message("성장기록 수정 성공")
             .build();
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -6,6 +6,7 @@ import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdat
 import com.codeit.donggrina.domain.growth_history.service.GrowthHistoryService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,7 +28,7 @@ public class GrowthHistoryController {
         Long memberId = member.getMemberId();
         Long result = growthHistoryService.append(memberId, request);
         return ApiResponse.<Long>builder()
-            .code(200)
+            .code(HttpStatus.OK.value())
             .message("성장기록 추가 성공")
             .data(result)
             .build();
@@ -42,7 +43,7 @@ public class GrowthHistoryController {
         Long memberId = member.getMemberId();
         growthHistoryService.update(memberId, growthId, request);
         return ApiResponse.<Void>builder()
-            .code(200)
+            .code(HttpStatus.OK.value())
             .message("성장기록 수정 성공")
             .build();
     }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/GrowthHistoryUpdateRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/GrowthHistoryUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.codeit.donggrina.domain.growth_history.dto.request;
+
+import com.codeit.donggrina.domain.growth_history.entity.GrowthHistoryCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record GrowthHistoryUpdateRequest(
+    @NotNull(message = "날짜를 입력해주세요.")
+    LocalDate date,
+    @NotBlank(message = "반려동물을 선택해주세요.")
+    String petName,
+    @NotNull(message = "카테고리를 입력해주세요.")
+    GrowthHistoryCategory category,
+    GrowthHistoryContentDto content
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,10 +32,10 @@ public class GrowthHistory extends Timestamp {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pet_id")
     private Pet pet;
     @Column(nullable = false)

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
@@ -1,6 +1,7 @@
 package com.codeit.donggrina.domain.growth_history.entity;
 
 import com.codeit.donggrina.common.Timestamp;
+import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
 import com.codeit.donggrina.domain.growth_history.util.CategoryEnumConverter;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.pet.entity.Pet;
@@ -57,7 +58,7 @@ public class GrowthHistory extends Timestamp {
     @Builder
     private GrowthHistory(Member member, Pet pet, LocalDate date, GrowthHistoryCategory category,
         String food, String snack, String abnormalSymptom, String hospitalName, String symptom,
-        String diagnosis, String medicationMethod, int price, String memo) {
+        String diagnosis, String medicationMethod, Integer price, String memo) {
         this.member = member;
         this.pet = pet;
         this.date = date;
@@ -71,5 +72,19 @@ public class GrowthHistory extends Timestamp {
         this.medicationMethod = medicationMethod;
         this.price = price;
         this.memo = memo;
+    }
+
+    public void update(GrowthHistoryUpdateRequest request) {
+        this.date = request.date();
+        this.category = request.category();
+        this.food = request.content().food();
+        this.snack = request.content().snack();
+        this.abnormalSymptom = request.content().abnormalSymptom();
+        this.hospitalName = request.content().hospitalName();
+        this.symptom = request.content().symptom();
+        this.diagnosis = request.content().diagnosis();
+        this.medicationMethod = request.content().medicationMethod();
+        this.price = request.content().price();
+        this.memo = request.content().memo();
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -3,6 +3,7 @@ package com.codeit.donggrina.domain.growth_history.service;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
+import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
 import com.codeit.donggrina.domain.growth_history.repository.GrowthHistoryRepository;
 import com.codeit.donggrina.domain.member.entity.Member;
@@ -57,5 +58,17 @@ public class GrowthHistoryService {
             .memo(request.content().memo())
             .build();
         return growthHistoryRepository.save(growthHistory).getId();
+    }
+
+    @Transactional
+    public void update(Long memberId, Long growthId, GrowthHistoryUpdateRequest request) {
+        // 로그인 한 사용자를 조회합니다.
+        memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // GrowthHistory를 조회하고 수정합니다.
+        GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
+        growthHistory.update(request);
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.codeit.donggrina.domain.member.entity;
 import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
 import com.codeit.donggrina.domain.group.entity.Group;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,11 +25,11 @@ public class Member {
     private String username;
     private String name;
     private String role;
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
     private String nickname; // 그룹 내에서 사용할 닉네임
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "clusters_id")
     private Group group;
 

--- a/src/main/java/com/codeit/donggrina/domain/pet/entity/Pet.java
+++ b/src/main/java/com/codeit/donggrina/domain/pet/entity/Pet.java
@@ -4,6 +4,7 @@ import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
 import com.codeit.donggrina.domain.group.entity.Group;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,10 +34,10 @@ public class Pet {
     private double weight;
     private boolean isNeutered;
     private String registrationNumber;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
 


### PR DESCRIPTION
## Issue Link
close #49 

## To Reviewers
성장 기록 수정 기능 구현했습니다.

쿼리 관련해서 궁금한 것이 있습니다. 지금 ManyToOne, OneToOne 등으로 묶인 것들이 fetchType이 디폴트라 EAGER 로 돼 있는 것들이 좀 있는 것 같습니다. 그래서인지 쿼리를 보면 join이 엄청 되고 있더라구요. 아까 성장기록 추가할 때도 그렇고, 지금 수정할 때도 그렇네요.

예시를 보면 성장 기록 수정하는 지금 로직에서 나가는 쿼리 보면 이렇게 나가요.
<img width="360" alt="1" src="https://github.com/Donggrina/Backend/assets/100478841/f5c095a6-5e7e-4aaa-80bd-e8f6ceaa0cbd">
<img width="454" alt="2" src="https://github.com/Donggrina/Backend/assets/100478841/ca423df1-f8f6-4b59-a43d-af2c4a39bec1">

음 이걸 어떤 식으로 하는게 좋을지 민우님 의견이 궁금하네용.

## Reference
