### PR TITLE
성장기록 삭제 기능 구현, 성장기록 수정 기능 보강

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -8,6 +8,7 @@ import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -45,6 +46,19 @@ public class GrowthHistoryController {
         return ApiResponse.<Void>builder()
             .code(HttpStatus.OK.value())
             .message("성장기록 수정 성공")
+            .build();
+    }
+
+    @DeleteMapping("/growth/{growthId}")
+    public ApiResponse<Void> delete(
+        @PathVariable Long growthId,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        growthHistoryService.delete(memberId, growthId);
+        return ApiResponse.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .message("성장기록 삭제 성공")
             .build();
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -69,6 +69,24 @@ public class GrowthHistoryService {
         // GrowthHistory를 조회하고 수정합니다.
         GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
+        if (!growthHistory.getMember().getId().equals(memberId)) {
+            throw new IllegalArgumentException("본인의 성장기록만 수정할 수 있습니다.");
+        }
         growthHistory.update(request);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long growthId) {
+        // 로그인 한 사용자를 조회합니다.
+        memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // GrowthHistory를 조회하고 삭제합니다.
+        GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
+        if (!growthHistory.getMember().getId().equals(memberId)) {
+            throw new IllegalArgumentException("본인의 성장기록만 삭제할 수 있습니다.");
+        }
+        growthHistoryRepository.delete(growthHistory);
     }
 }


### PR DESCRIPTION
## Issue Link
close #59 

## To Reviewers
- 성장기록 삭제하는 기능을 구현했습니다.
- 성장기록 수정 시 삭제와 마찬가지로 본인이 쓴 기록에 대해서만 수정할 수 있도록 검증하는 부분을 추가하였습니다.
- JWT 를 사용할 수 없어서 HTTP 클라이언트로 테스트를 못 해 봤습니다 ㅠ
## Reference
