### PR TITLE
성장 기록 상세 조회

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -3,12 +3,14 @@ package com.codeit.donggrina.domain.growth_history.controller;
 import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.service.GrowthHistoryService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,6 +22,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class GrowthHistoryController {
 
     private final GrowthHistoryService growthHistoryService;
+
+    @GetMapping("/growth/{growthId}")
+    public ApiResponse<GrowthHistoryDetailResponse> getDetail(
+        @PathVariable Long growthId
+    ) {
+        return ApiResponse.<GrowthHistoryDetailResponse>builder()
+            .code(HttpStatus.OK.value())
+            .message("성장기록 상세 조회 성공")
+            .data(growthHistoryService.getDetail(growthId))
+            .build();
+    }
 
     @PostMapping("/growth")
     public ApiResponse<Long> append(

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/GrowthHistoryContentDto.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/GrowthHistoryContentDto.java
@@ -1,5 +1,8 @@
-package com.codeit.donggrina.domain.growth_history.dto.request;
+package com.codeit.donggrina.domain.growth_history.dto;
 
+import lombok.Builder;
+
+@Builder
 public record GrowthHistoryContentDto(
     String food,
     String snack,

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/GrowthHistoryAppendRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/GrowthHistoryAppendRequest.java
@@ -1,5 +1,6 @@
 package com.codeit.donggrina.domain.growth_history.dto.request;
 
+import com.codeit.donggrina.domain.growth_history.dto.GrowthHistoryContentDto;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistoryCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/GrowthHistoryUpdateRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/GrowthHistoryUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.codeit.donggrina.domain.growth_history.dto.request;
 
+import com.codeit.donggrina.domain.growth_history.dto.GrowthHistoryContentDto;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistoryCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/response/GrowthHistoryDetailResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/response/GrowthHistoryDetailResponse.java
@@ -1,0 +1,41 @@
+package com.codeit.donggrina.domain.growth_history.dto.response;
+
+import com.codeit.donggrina.domain.growth_history.dto.GrowthHistoryContentDto;
+import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
+import com.codeit.donggrina.domain.growth_history.entity.GrowthHistoryCategory;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GrowthHistoryDetailResponse(
+    Long id,
+    String writerProfileImageUrl,
+    String petProfileImageUrl,
+    GrowthHistoryCategory category,
+    GrowthHistoryContentDto content,
+    LocalDateTime dateTime,
+    String nickname
+) {
+    public static GrowthHistoryDetailResponse from(GrowthHistory growthHistory) {
+        GrowthHistoryContentDto content = GrowthHistoryContentDto.builder()
+            .food(growthHistory.getFood())
+            .snack(growthHistory.getSnack())
+            .abnormalSymptom(growthHistory.getAbnormalSymptom())
+            .hospitalName(growthHistory.getHospitalName())
+            .symptom(growthHistory.getSymptom())
+            .diagnosis(growthHistory.getDiagnosis())
+            .medicationMethod(growthHistory.getMedicationMethod())
+            .price(growthHistory.getPrice())
+            .memo(growthHistory.getMemo())
+            .build();
+        return GrowthHistoryDetailResponse.builder()
+            .id(growthHistory.getId())
+            .writerProfileImageUrl(growthHistory.getMember().getProfileImage().getUrl())
+            .petProfileImageUrl(growthHistory.getPet().getProfileImage().getUrl())
+            .category(growthHistory.getCategory())
+            .content(content)
+            .dateTime(growthHistory.getCreatedAt())
+            .nickname(growthHistory.getMember().getNickname())
+            .build();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.codeit.donggrina.domain.growth_history.repository;
+
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
+
+public interface CustomGrowthHistoryRepository {
+
+    GrowthHistoryDetailResponse findGrowthHistoryDetail(Long growthId);
+}

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.codeit.donggrina.domain.growth_history.repository;
+
+import static com.codeit.donggrina.domain.growth_history.entity.QGrowthHistory.growthHistory;
+import static com.codeit.donggrina.domain.member.entity.QMember.member;
+import static com.codeit.donggrina.domain.pet.entity.QPet.pet;
+
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
+import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomGrowthHistoryRepositoryImpl implements CustomGrowthHistoryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public GrowthHistoryDetailResponse findGrowthHistoryDetail(Long growthId) {
+        GrowthHistory findGrowthHistory = queryFactory
+            .selectFrom(growthHistory)
+            .leftJoin(growthHistory.member, member).fetchJoin()
+            .leftJoin(member.profileImage).fetchJoin()
+            .leftJoin(growthHistory.pet, pet).fetchJoin()
+            .leftJoin(pet.profileImage).fetchJoin()
+            .where(growthHistory.id.eq(growthId))
+            .fetchOne();
+        if (findGrowthHistory == null) {
+            throw new IllegalArgumentException("존재하지 않는 성장기록입니다.");
+        }
+        return GrowthHistoryDetailResponse.from(findGrowthHistory);
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/GrowthHistoryRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/GrowthHistoryRepository.java
@@ -3,6 +3,6 @@ package com.codeit.donggrina.domain.growth_history.repository;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GrowthHistoryRepository extends JpaRepository<GrowthHistory, Long> {
+public interface GrowthHistoryRepository extends JpaRepository<GrowthHistory, Long>, CustomGrowthHistoryRepository {
 
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -4,6 +4,7 @@ import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
 import com.codeit.donggrina.domain.growth_history.repository.GrowthHistoryRepository;
 import com.codeit.donggrina.domain.member.entity.Member;
@@ -20,6 +21,10 @@ public class GrowthHistoryService {
     private final GrowthHistoryRepository growthHistoryRepository;
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+
+    public GrowthHistoryDetailResponse getDetail(Long growthId) {
+        return growthHistoryRepository.findGrowthHistoryDetail(growthId);
+    }
 
     @Transactional
     public Long append(Long memberId, GrowthHistoryAppendRequest request) {


### PR DESCRIPTION
## Issue Link
close #64 

## To Reviewers
성장기록 상세 조회 기능입니다.
- `GrowthHistory`, `Member`, `Pet`, `ProfileImage` 를 leftJoin + fetchJoin 해서 조회합니다.
- request 와 response 에서 다 사용하기 때문에 `GrowthHistoryContentDto` 패키지 위치를 변경시켰습니다. 
- 현재 기능에서 이미지 테이블에 이미지가 저장돼 있지 않으면 데이터가 조회되지않고 null 로 반환됩니다. 그런데 프로필 이미지 동의를 안 해도 기본 이미지가 무조건 url로 저장되기 때문에 이 부분은 괜찮을 것 같습니다.
## Reference
