### PR TITLE
성장기록 날짜별 조회

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -4,8 +4,12 @@ import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.service.GrowthHistoryService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +27,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class GrowthHistoryController {
 
     private final GrowthHistoryService growthHistoryService;
+
+    @GetMapping("/growth")
+    public ApiResponse<List<GrowthHistoryListResponse>> getByDate(
+        @RequestParam @Nullable LocalDate date
+    ) {
+        return ApiResponse.<List<GrowthHistoryListResponse>>builder()
+            .code(HttpStatus.OK.value())
+            .message("성장기록 날짜별 조회 성공")
+            .data(growthHistoryService.getByDate(date))
+            .build();
+    }
 
     @GetMapping("/growth/{growthId}")
     public ApiResponse<GrowthHistoryDetailResponse> getDetail(

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/response/GrowthHistoryListResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/response/GrowthHistoryListResponse.java
@@ -1,0 +1,27 @@
+package com.codeit.donggrina.domain.growth_history.dto.response;
+
+import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
+import com.codeit.donggrina.domain.growth_history.entity.GrowthHistoryCategory;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GrowthHistoryListResponse(
+    Long id,
+    String writerProfileImageUrl,
+    String petProfileImageUrl,
+    GrowthHistoryCategory category,
+    LocalDateTime dateTime,
+    String nickname
+) {
+    public static GrowthHistoryListResponse from(GrowthHistory growthHistory) {
+        return GrowthHistoryListResponse.builder()
+            .id(growthHistory.getId())
+            .writerProfileImageUrl(growthHistory.getMember().getProfileImage().getUrl())
+            .petProfileImageUrl(growthHistory.getPet().getProfileImage().getUrl())
+            .category(growthHistory.getCategory())
+            .dateTime(growthHistory.getCreatedAt())
+            .nickname(growthHistory.getMember().getNickname())
+            .build();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
@@ -1,8 +1,13 @@
 package com.codeit.donggrina.domain.growth_history.repository;
 
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
+import java.time.LocalDate;
+import java.util.List;
 
 public interface CustomGrowthHistoryRepository {
+
+    List<GrowthHistoryListResponse> findGrowthHistoryDetailByDate(LocalDate date);
 
     GrowthHistoryDetailResponse findGrowthHistoryDetail(Long growthId);
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
@@ -5,14 +5,36 @@ import static com.codeit.donggrina.domain.member.entity.QMember.member;
 import static com.codeit.donggrina.domain.pet.entity.QPet.pet;
 
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class CustomGrowthHistoryRepositoryImpl implements CustomGrowthHistoryRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<GrowthHistoryListResponse> findGrowthHistoryDetailByDate(LocalDate date) {
+        if (date == null) {
+            date = LocalDate.now();
+        }
+        return queryFactory
+            .selectFrom(growthHistory)
+            .leftJoin(growthHistory.member, member).fetchJoin()
+            .leftJoin(member.profileImage).fetchJoin()
+            .leftJoin(growthHistory.pet, pet).fetchJoin()
+            .leftJoin(pet.profileImage).fetchJoin()
+            .where(growthHistory.date.eq(date))
+            .orderBy(growthHistory.id.desc())
+            .fetch()
+            .stream()
+            .map(GrowthHistoryListResponse::from)
+            .toList();
+    }
 
     @Override
     public GrowthHistoryDetailResponse findGrowthHistoryDetail(Long growthId) {

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -5,12 +5,15 @@ import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
+import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
 import com.codeit.donggrina.domain.growth_history.repository.GrowthHistoryRepository;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import com.codeit.donggrina.domain.pet.entity.Pet;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +24,10 @@ public class GrowthHistoryService {
     private final GrowthHistoryRepository growthHistoryRepository;
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+
+    public List<GrowthHistoryListResponse> getByDate(LocalDate date) {
+        return growthHistoryRepository.findGrowthHistoryDetailByDate(date);
+    }
 
     public GrowthHistoryDetailResponse getDetail(Long growthId) {
         return growthHistoryRepository.findGrowthHistoryDetail(growthId);


### PR DESCRIPTION
## Issue Link
close #67 

## To Reviewers
메인페이지와 성장기록 탭에서 날짜를 조건으로 하여 리스트 형식으로 조회하는 API 입니다.
- RequestParam으로 date 를 받습니다.
- RequestParam을 nullable 하게 하고 쿼리 쪽에서 혹시 null 로 들어오면 디폴트로 오늘 날짜를 조회하도록 하였습니다.
- 리스트 형식에서는 content 는 굳이 필요없을 것 같아서 별도의 ResponseDto 를 만들었습니다.
- id 기준으로 최신순 정렬로 조회하도록 하였습니다.

## Reference
