### PR TITLE
S3 와 프로필 이미지 데이터베이스 스케줄링 삭제

### DIFF
--- a/src/main/java/com/codeit/donggrina/DonggrinaApplication.java
+++ b/src/main/java/com/codeit/donggrina/DonggrinaApplication.java
@@ -3,9 +3,11 @@ package com.codeit.donggrina;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class DonggrinaApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/codeit/donggrina/common/api/ApiControllerAdvice.java
+++ b/src/main/java/com/codeit/donggrina/common/api/ApiControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.codeit.donggrina.common.api;
 
+import com.codeit.donggrina.domain.ProfileImage.exception.ImageDeleteException;
 import com.codeit.donggrina.domain.ProfileImage.exception.ImageUploadException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -61,14 +62,27 @@ public class ApiControllerAdvice {
     }
 
     /**
-     * ImageUploadException 발생 시, 잘못된 요청에 대한 응답을 반환합니다.
+     * ImageUploadException 발생 시, 서버 에러에 대한 응답을 반환합니다.
      *
-     * @param e ImageUploadException
      * @return ErrorResponse
      */
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(ImageUploadException.class)
-    public ErrorResponse imageUploadExceptionHandler(ImageUploadException e) {
+    public ErrorResponse imageUploadExceptionHandler() {
+        return ErrorResponse.builder()
+            .code(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            .message("서버 에러입니다.")
+            .build();
+    }
+
+    /**
+     * ImageDeleteException 발생 시, 서버 에러에 대한 응답을 반환합니다.
+     *
+     * @return ErrorResponse
+     */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(ImageDeleteException.class)
+    public ErrorResponse imageDeleteExceptionHandler() {
         return ErrorResponse.builder()
             .code(HttpStatus.INTERNAL_SERVER_ERROR.value())
             .message("서버 에러입니다.")

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/exception/ImageDeleteException.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/exception/ImageDeleteException.java
@@ -1,0 +1,8 @@
+package com.codeit.donggrina.domain.ProfileImage.exception;
+
+public class ImageDeleteException extends RuntimeException {
+
+    public ImageDeleteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/repository/CustomProfileImageRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/repository/CustomProfileImageRepository.java
@@ -1,0 +1,8 @@
+package com.codeit.donggrina.domain.ProfileImage.repository;
+
+import java.util.List;
+
+public interface CustomProfileImageRepository {
+
+    List<Long> findUnlinkedProfileImageIds();
+}

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/repository/CustomProfileImageRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/repository/CustomProfileImageRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.codeit.donggrina.domain.ProfileImage.repository;
+
+import static com.codeit.donggrina.domain.ProfileImage.entity.QProfileImage.profileImage;
+import static com.codeit.donggrina.domain.member.entity.QMember.member;
+import static com.codeit.donggrina.domain.pet.entity.QPet.pet;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomProfileImageRepositoryImpl implements CustomProfileImageRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Long> findUnlinkedProfileImageIds() {
+        return queryFactory
+            .select(profileImage.id)
+            .from(profileImage)
+            .leftJoin(member).on(profileImage.id.eq(member.profileImage.id))
+            .leftJoin(pet).on(profileImage.id.eq(pet.profileImage.id))
+            .where(member.profileImage.id.isNull().and(pet.profileImage.id.isNull()))
+            .fetch();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/repository/ProfileImageRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/repository/ProfileImageRepository.java
@@ -3,6 +3,6 @@ package com.codeit.donggrina.domain.ProfileImage.repository;
 import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long>, CustomProfileImageRepository {
 
 }

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/service/ProfileImageService.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/service/ProfileImageService.java
@@ -2,24 +2,27 @@ package com.codeit.donggrina.domain.ProfileImage.service;
 
 import com.codeit.donggrina.domain.ProfileImage.entity.ProfileImage;
 import com.codeit.donggrina.domain.ProfileImage.repository.ProfileImageRepository;
-import com.codeit.donggrina.domain.ProfileImage.util.S3Uploader;
+import com.codeit.donggrina.domain.ProfileImage.util.S3Handler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ProfileImageService {
 
     private final ProfileImageRepository imageRepository;
-    private final S3Uploader s3Uploader;
+    private final S3Handler s3Handler;
 
     public List<Long> uploadImage(List<MultipartFile> files) {
         List<CompletableFuture<Long>> futures = files.stream()
-            .map(file -> s3Uploader.upload(file)
+            .map(file -> s3Handler.upload(file)
                 .thenApply(imageUrl -> {
                     ProfileImage profileImage = ProfileImage.builder()
                         .name(file.getOriginalFilename())
@@ -34,5 +37,23 @@ public class ProfileImageService {
         futures.forEach(future -> ids.add(future.join()));
 
         return ids;
+    }
+
+    /**
+     * 매일 자정에 S3와 DB에 저장된 프로필 이미지 중, Member 또는 Pet과 연결되지 않은 데이터 삭제
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void deleteUnlinkedImageInDBAndS3() {
+        List<Long> unlinkedProfileImageIds = imageRepository.findUnlinkedProfileImageIds();
+        unlinkedProfileImageIds.forEach(id -> {
+            ProfileImage profileImage = imageRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.error("프로필 이미지 스케줄링 삭제 중 오류, 존재하지 않는 id={}", id);
+                    return new IllegalArgumentException("존재하지 않는 프로필 이미지입니다.");
+                });
+            String fileName = profileImage.getUrl().split("/")[3];
+            CompletableFuture<Void> deleteFuture = s3Handler.delete(fileName);
+            deleteFuture.thenRun(() -> imageRepository.delete(profileImage));
+        });
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/util/S3Handler.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/util/S3Handler.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -15,7 +16,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @RequiredArgsConstructor
-public class S3Uploader {
+@Slf4j
+public class S3Handler {
 
     private final AmazonS3Client amazonS3Client;
 
@@ -46,4 +48,15 @@ public class S3Uploader {
         return future;
     }
 
+    @Async("imageUploadExecutor")
+    public CompletableFuture<Void> delete(String fileName) {
+        return CompletableFuture
+            .runAsync(() -> {
+                amazonS3Client.deleteObject(bucket, fileName);
+                log.info("S3 이미지 삭제 완료, fileName={}", fileName);
+            })
+            .exceptionally(e -> {
+                throw new RuntimeException("S3 이미지 삭제 중 오류가 발생했습니다.", e);
+            });
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/ProfileImage/util/S3Handler.java
+++ b/src/main/java/com/codeit/donggrina/domain/ProfileImage/util/S3Handler.java
@@ -2,6 +2,7 @@ package com.codeit.donggrina.domain.ProfileImage.util;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.codeit.donggrina.domain.ProfileImage.exception.ImageDeleteException;
 import com.codeit.donggrina.domain.ProfileImage.exception.ImageUploadException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,7 +57,8 @@ public class S3Handler {
                 log.info("S3 이미지 삭제 완료, fileName={}", fileName);
             })
             .exceptionally(e -> {
-                throw new RuntimeException("S3 이미지 삭제 중 오류가 발생했습니다.", e);
+                log.error("S3에서 이미지 삭제 중 오류 발생, fileName={}", fileName, e);
+                throw new ImageDeleteException("S3 이미지 삭제 중 오류가 발생했습니다.", e);
             });
     }
 }


### PR DESCRIPTION
## Issue Link
close #70 

## To Reviewers
- 프로필 이미지 저장만 하고 요청이 완료되지 않아서 프로필 이미지가 Member 또는 Pet 과 연결되지 않은 데이터들을 스케줄링으로 삭제합니다.
- 네트워크 요청이 필요한 S3 삭제는 비동기로 구현해봤습니다.
- 매일 자정에 스케줄러가 돌아갑니다.

이 기능은 성공하거나 예외가 발생했을 때 인지하기 쉽게 하기 위해서 log 를 따로 남겨놨습니다.

## Reference
