### PR TITLE
성장기록 검색 기능 구현

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -3,6 +3,7 @@ package com.codeit.donggrina.domain.growth_history.controller;
 import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
+import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.service.GrowthHistoryService;
@@ -47,6 +48,17 @@ public class GrowthHistoryController {
             .code(HttpStatus.OK.value())
             .message("성장기록 상세 조회 성공")
             .data(growthHistoryService.getDetail(growthId))
+            .build();
+    }
+
+    @GetMapping("/growth/search")
+    public ApiResponse<List<GrowthHistoryListResponse>> search(
+        SearchFilter searchFilter
+    ) {
+        return ApiResponse.<List<GrowthHistoryListResponse>>builder()
+            .code(HttpStatus.OK.value())
+            .message("성장기록 검색 성공")
+            .data(growthHistoryService.search(searchFilter))
             .build();
     }
 

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/SearchFilter.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/dto/request/SearchFilter.java
@@ -1,0 +1,11 @@
+package com.codeit.donggrina.domain.growth_history.dto.request;
+
+import java.util.List;
+
+public record SearchFilter(
+    String keyword,
+    List<String> petNames,
+    List<String> writerNames
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
@@ -48,12 +48,12 @@ public class GrowthHistory extends Timestamp {
     private String abnormalSymptom;
     private String hospitalName;
     private String symptom;
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String diagnosis;
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String medicationMethod;
     private Integer price;
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String memo;
 
     @Builder

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.codeit.donggrina.domain.growth_history.repository;
 
+import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import java.time.LocalDate;
@@ -10,4 +11,6 @@ public interface CustomGrowthHistoryRepository {
     List<GrowthHistoryListResponse> findGrowthHistoryDetailByDate(LocalDate date);
 
     GrowthHistoryDetailResponse findGrowthHistoryDetail(Long growthId);
+
+    List<GrowthHistoryListResponse> findGrowthHistoryBySearchFilter(SearchFilter searchFilter);
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
@@ -4,9 +4,11 @@ import static com.codeit.donggrina.domain.growth_history.entity.QGrowthHistory.g
 import static com.codeit.donggrina.domain.member.entity.QMember.member;
 import static com.codeit.donggrina.domain.pet.entity.QPet.pet;
 
+import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
@@ -50,5 +52,48 @@ public class CustomGrowthHistoryRepositoryImpl implements CustomGrowthHistoryRep
             throw new IllegalArgumentException("존재하지 않는 성장기록입니다.");
         }
         return GrowthHistoryDetailResponse.from(findGrowthHistory);
+    }
+
+    @Override
+    public List<GrowthHistoryListResponse> findGrowthHistoryBySearchFilter(
+        SearchFilter searchFilter) {
+        return queryFactory
+            .selectFrom(growthHistory)
+            .leftJoin(growthHistory.member, member).fetchJoin()
+            .leftJoin(member.profileImage).fetchJoin()
+            .leftJoin(growthHistory.pet, pet).fetchJoin()
+            .leftJoin(pet.profileImage).fetchJoin()
+            .where(
+                containsKeyword(searchFilter.keyword()),
+                inPetNames(searchFilter.petNames()),
+                inWriterNames(searchFilter.writerNames())
+            )
+            .orderBy(growthHistory.id.desc())
+            .fetch()
+            .stream()
+            .map(GrowthHistoryListResponse::from)
+            .toList();
+    }
+
+    private BooleanExpression containsKeyword(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        return growthHistory.food.containsIgnoreCase(keyword)
+            .or(growthHistory.snack.containsIgnoreCase(keyword))
+            .or(growthHistory.abnormalSymptom.containsIgnoreCase(keyword))
+            .or(growthHistory.hospitalName.containsIgnoreCase(keyword))
+            .or(growthHistory.symptom.containsIgnoreCase(keyword))
+            .or(growthHistory.diagnosis.containsIgnoreCase(keyword))
+            .or(growthHistory.medicationMethod.containsIgnoreCase(keyword))
+            .or(growthHistory.memo.containsIgnoreCase(keyword));
+    }
+
+    private BooleanExpression inPetNames(List<String> petNames) {
+        return petNames.isEmpty() ? null : pet.name.in(petNames);
+    }
+
+    private BooleanExpression inWriterNames(List<String> writerNames) {
+        return writerNames.isEmpty() ? null : member.nickname.in(writerNames);
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -4,6 +4,7 @@ import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
+import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
@@ -31,6 +32,10 @@ public class GrowthHistoryService {
 
     public GrowthHistoryDetailResponse getDetail(Long growthId) {
         return growthHistoryRepository.findGrowthHistoryDetail(growthId);
+    }
+
+    public List<GrowthHistoryListResponse> search(SearchFilter searchFilter) {
+        return growthHistoryRepository.findGrowthHistoryBySearchFilter(searchFilter);
     }
 
     @Transactional


### PR DESCRIPTION
## Issue Link
close #72 

## To Reviewers
성장기록 검색 기능 구현했습니다.
- keyword
- 반려동물 이름(복수 선택 가능)
- 작성자 닉네임(복수 선택 가능)

조회 응답은 리스트 응답과 동일하게 했습니다. 본문 내용은 필요 없을 것 같아서요.

페이징은 넣을까 하다가 일단 기획사항에 없어서 추가하지 않았습니다. 키워드, 필터 조합하면 그렇게 많이 조회되지 않을 것 같기도 합니다.

## Reference
