### PR TITLE
일정 완료 여부 상태 업데이트 기능

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
@@ -62,6 +62,19 @@ public class CalendarController {
             .build();
     }
 
+    @PutMapping("/calendar/completion/{calendarId}")
+    public ApiResponse<Void> updateCompletionState(
+        @PathVariable Long calendarId,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        calendarService.updateCompletionState(memberId, calendarId);
+        return ApiResponse.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .message("일정 완료 여부 변경 성공")
+            .build();
+    }
+
     @DeleteMapping("/calendar/{calendarId}")
     public ApiResponse<Void> delete(
         @PathVariable Long calendarId,

--- a/src/main/java/com/codeit/donggrina/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/entity/Calendar.java
@@ -60,4 +60,8 @@ public class Calendar extends Timestamp {
         this.dateTime = LocalDateTime.parse(request.dateTime());
         this.pet = pet;
     }
+
+    public void updateCompletion() {
+        this.isFinished = !this.isFinished;
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -89,6 +89,17 @@ public class CalendarService {
     }
 
     @Transactional
+    public void updateCompletionState(Long memberId, Long calendarId) {
+        // 일정을 조회하고 완료 여부를 수정합니다. 본인이 작성한 일정이 아니면 예외를 발생시킵니다.
+        Calendar calendar = calendarRepository.findById(calendarId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 일정입니다."));
+        if (!calendar.getMember().getId().equals(memberId)) {
+            throw new IllegalArgumentException("본인이 작성한 일정만 완료 처리 할 수 있습니다.");
+        }
+        calendar.updateCompletion();
+    }
+
+    @Transactional
     public void delete(Long memberId, Long calendarId) {
         // 일정을 조회하고 삭제합니다. 본인이 작성한 일정이 아니면 예외를 발생시킵니다.
         Calendar calendar = calendarRepository.findById(calendarId)


### PR DESCRIPTION
## Issue Link
close #87 

## To Reviewers
일정의 완료 상태를 변경합니다. DB에서 조회한 일정의 완료여부가 false 면 true 로, true 면 false 로 변경합니다.
일정 상태를 업데이트 할 때마다 DB에 요청이 가긴 하지만 서비스 자체가 크지 않고, 요청이 한 번에 많이 몰릴 것 같지는 않아서 당장은 큰 상관은 없을 것 같습니다.

## Reference
