### PR TITLE
일정 전체 조회(월별, 일별)

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
@@ -4,8 +4,11 @@ import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarAppendRequest;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarUpdateRequest;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.service.CalendarService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +27,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class CalendarController {
 
     private final CalendarService calendarService;
+
+    @GetMapping("/calendar/day")
+    public ApiResponse<List<CalendarListResponse>> getDayListByDate(
+        @RequestParam LocalDate date,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        return ApiResponse.<List<CalendarListResponse>>builder()
+            .code(HttpStatus.OK.value())
+            .message("일정 목록 일별 조회 성공")
+            .data(calendarService.getDayListByDate(memberId, date))
+            .build();
+    }
 
     @GetMapping("/calendar/{calendarId}")
     public ApiResponse<CalendarDetailResponse> getDetail(

--- a/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
@@ -8,6 +8,7 @@ import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.service.CalendarService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
+import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -32,7 +33,7 @@ public class CalendarController {
 
     @GetMapping("/calendar/month")
     public ApiResponse<List<CalendarDailyCountResponse>> getDailyCountByMonth(
-        @RequestParam YearMonth yearMonth,
+        @RequestParam @Nullable YearMonth yearMonth,
         @AuthenticationPrincipal CustomOAuth2User member
     ) {
         Long memberId = member.getMemberId();
@@ -45,7 +46,7 @@ public class CalendarController {
 
     @GetMapping("/calendar/day")
     public ApiResponse<List<CalendarListResponse>> getDayListByDate(
-        @RequestParam LocalDate date,
+        @RequestParam @Nullable LocalDate date,
         @AuthenticationPrincipal CustomOAuth2User member
     ) {
         Long memberId = member.getMemberId();

--- a/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
@@ -3,11 +3,13 @@ package com.codeit.donggrina.domain.calendar.controller;
 import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarAppendRequest;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarUpdateRequest;
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarDailyCountResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.service.CalendarService;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,6 +29,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class CalendarController {
 
     private final CalendarService calendarService;
+
+    @GetMapping("/calendar/month")
+    public ApiResponse<List<CalendarDailyCountResponse>> getDailyCountByMonth(
+        @RequestParam YearMonth yearMonth,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        return ApiResponse.<List<CalendarDailyCountResponse>>builder()
+            .code(HttpStatus.OK.value())
+            .message("일정 목록 월별 조회 성공")
+            .data(calendarService.getDailyCountByMonth(memberId, yearMonth))
+            .build();
+    }
 
     @GetMapping("/calendar/day")
     public ApiResponse<List<CalendarListResponse>> getDayListByDate(

--- a/src/main/java/com/codeit/donggrina/domain/calendar/dto/response/CalendarDailyCountResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/dto/response/CalendarDailyCountResponse.java
@@ -1,0 +1,16 @@
+package com.codeit.donggrina.domain.calendar.dto.response;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class CalendarDailyCountResponse {
+
+    private final String date;
+    private final long count;
+
+    public CalendarDailyCountResponse(int year, int month, int dayOfMonth, long count) {
+        this.date = LocalDate.of(year, month, dayOfMonth).toString();
+        this.count = count;
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/calendar/dto/response/CalendarListResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/dto/response/CalendarListResponse.java
@@ -1,0 +1,31 @@
+package com.codeit.donggrina.domain.calendar.dto.response;
+
+import com.codeit.donggrina.domain.calendar.entity.Calendar;
+import com.codeit.donggrina.domain.calendar.entity.CalendarCategory;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record CalendarListResponse(
+    Long id,
+    String title,
+    CalendarCategory category,
+    LocalDateTime dateTime,
+    String memberProfileImageUrl,
+    String nickname,
+    String petProfileImageUrl
+) {
+
+    public static CalendarListResponse from(Calendar calendar) {
+        return CalendarListResponse.builder()
+            .id(calendar.getId())
+            .title(calendar.getTitle())
+            .category(calendar.getCategory())
+            .dateTime(calendar.getDateTime())
+            .memberProfileImageUrl(calendar.getMember().getProfileImage().getUrl())
+            .nickname(calendar.getMember().getNickname())
+            .petProfileImageUrl(calendar.getPet().getProfileImage().getUrl())
+            .build();
+    }
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
@@ -1,8 +1,13 @@
 package com.codeit.donggrina.domain.calendar.repository;
 
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
+import java.time.LocalDate;
+import java.util.List;
 
 public interface CustomCalendarRepository {
+
+    List<CalendarListResponse> getDayListByDate(Long groupId, LocalDate date);
 
     CalendarDetailResponse getDetail(Long calendarId);
 }

--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
@@ -1,11 +1,15 @@
 package com.codeit.donggrina.domain.calendar.repository;
 
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarDailyCountResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 public interface CustomCalendarRepository {
+
+    List<CalendarDailyCountResponse> getDailyCountByMonth(Long groupId, YearMonth yearMonth);
 
     List<CalendarListResponse> getDayListByDate(Long groupId, LocalDate date);
 

--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepositoryImpl.java
@@ -6,14 +6,40 @@ import static com.codeit.donggrina.domain.member.entity.QMember.member;
 import static com.codeit.donggrina.domain.pet.entity.QPet.pet;
 
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.entity.Calendar;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class CustomCalendarRepositoryImpl implements CustomCalendarRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CalendarListResponse> getDayListByDate(Long groupId, LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay(); // 조회하려는 날짜의 00:00:00
+        LocalDateTime endOfDay = date.atTime(23, 59, 59); // 조회하려는 날짜의 23:59:59
+
+        return queryFactory
+            .selectFrom(calendar)
+            .leftJoin(calendar.member, member).fetchJoin()
+            .leftJoin(member.profileImage).fetchJoin()
+            .leftJoin(calendar.pet, pet).fetchJoin()
+            .leftJoin(pet.profileImage).fetchJoin()
+            .where(
+                calendar.member.group.id.eq(groupId)
+                    .and(calendar.dateTime.between(startOfDay, endOfDay))
+            )
+            .orderBy(calendar.id.desc())
+            .fetch()
+            .stream()
+            .map(CalendarListResponse::from)
+            .toList();
+    }
 
     @Override
     public CalendarDetailResponse getDetail(Long calendarId) {

--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -32,6 +32,10 @@ public class CalendarService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         Long groupId = member.getGroup().getId();
+
+        if (yearMonth == null) {
+            yearMonth = YearMonth.now();
+        }
         return calendarRepository.getDailyCountByMonth(groupId, yearMonth);
     }
 
@@ -39,6 +43,9 @@ public class CalendarService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         Long groupId = member.getGroup().getId();
+        if (date == null) {
+            date = LocalDate.now();
+        }
         return calendarRepository.getDayListByDate(groupId, date);
     }
 

--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -2,6 +2,7 @@ package com.codeit.donggrina.domain.calendar.service;
 
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarAppendRequest;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarUpdateRequest;
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarDailyCountResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.entity.Calendar;
@@ -13,6 +14,7 @@ import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import com.codeit.donggrina.domain.pet.entity.Pet;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,13 @@ public class CalendarService {
     private final CalendarRepository calendarRepository;
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+
+    public List<CalendarDailyCountResponse> getDailyCountByMonth(Long memberId, YearMonth yearMonth) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Long groupId = member.getGroup().getId();
+        return calendarRepository.getDailyCountByMonth(groupId, yearMonth);
+    }
 
     public List<CalendarListResponse> getDayListByDate(Long memberId, LocalDate date) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -3,6 +3,7 @@ package com.codeit.donggrina.domain.calendar.service;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarAppendRequest;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarUpdateRequest;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
+import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.entity.Calendar;
 import com.codeit.donggrina.domain.calendar.repository.CalendarRepository;
 import com.codeit.donggrina.domain.group.entity.Group;
@@ -10,7 +11,9 @@ import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import com.codeit.donggrina.domain.pet.entity.Pet;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +25,13 @@ public class CalendarService {
     private final CalendarRepository calendarRepository;
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+
+    public List<CalendarListResponse> getDayListByDate(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Long groupId = member.getGroup().getId();
+        return calendarRepository.getDayListByDate(groupId, date);
+    }
 
     public CalendarDetailResponse getDetail(Long calendarId) {
         return calendarRepository.getDetail(calendarId);


### PR DESCRIPTION
## Issue Link
close #92 

## To Reviewers
일정을 월별, 일별로 조회하는 기능입니다.

- 월별로 조회할 때는 날짜별로 일정이 몇 개인지 반환합니다.
```json
{
  "code": 200,
  "message": "일정 목록 월별 조회 성공",
  "data": [
    {
      "date": "2024-06-07",
      "count": 1
    },
    {
      "date": "2024-06-10",
      "count": 2
    }
  ]
}
```

- 일별로 조회할 때는 내용을 제외한 다른 일정의 정보를 반환합니다.

생각해보니 날짜별로 조회를 할 때 groupId 도 조건에 넣어줘야 할 것 같아서 추가를 했습니다. (성장 기록 부분도 수정할 예정입니다.)
## Reference
