### PR TITLE
성장기록 날짜별 조회 시 그룹 id 조건 추가, 일정 검색 기능

### DIFF
--- a/src/main/java/com/codeit/donggrina/common/api/SearchFilter.java
+++ b/src/main/java/com/codeit/donggrina/common/api/SearchFilter.java
@@ -1,4 +1,4 @@
-package com.codeit.donggrina.domain.growth_history.dto.request;
+package com.codeit.donggrina.common.api;
 
 import java.util.List;
 

--- a/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/controller/CalendarController.java
@@ -7,6 +7,7 @@ import com.codeit.donggrina.domain.calendar.dto.response.CalendarDailyCountRespo
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.service.CalendarService;
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
@@ -65,6 +66,15 @@ public class CalendarController {
             .code(HttpStatus.OK.value())
             .message("일정 상세 조회 성공")
             .data(calendarService.getDetail(calendarId))
+            .build();
+    }
+
+    @GetMapping("/calendar/search")
+    public ApiResponse<List<CalendarListResponse>> search(SearchFilter searchFilter) {
+        return ApiResponse.<List<CalendarListResponse>>builder()
+            .code(HttpStatus.OK.value())
+            .message("일정 검색 성공")
+            .data(calendarService.search(searchFilter))
             .build();
     }
 

--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
@@ -3,6 +3,7 @@ package com.codeit.donggrina.domain.calendar.repository;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDailyCountResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDetailResponse;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
+import com.codeit.donggrina.common.api.SearchFilter;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -14,4 +15,6 @@ public interface CustomCalendarRepository {
     List<CalendarListResponse> getDayListByDate(Long groupId, LocalDate date);
 
     CalendarDetailResponse getDetail(Long calendarId);
+
+    List<CalendarListResponse> findBySearchFilter(SearchFilter searchFilter);
 }

--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepositoryImpl.java
@@ -103,6 +103,7 @@ public class CustomCalendarRepositoryImpl implements CustomCalendarRepository {
                 inPetNames(searchFilter.petNames()),
                 inWriterNames(searchFilter.writerNames())
             )
+            .orderBy(calendar.id.desc())
             .fetch()
             .stream()
             .map(CalendarListResponse::from)

--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -9,6 +9,7 @@ import com.codeit.donggrina.domain.calendar.entity.Calendar;
 import com.codeit.donggrina.domain.calendar.repository.CalendarRepository;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import com.codeit.donggrina.domain.pet.entity.Pet;
@@ -51,6 +52,10 @@ public class CalendarService {
 
     public CalendarDetailResponse getDetail(Long calendarId) {
         return calendarRepository.getDetail(calendarId);
+    }
+
+    public List<CalendarListResponse> search(SearchFilter searchFilter) {
+        return calendarRepository.findBySearchFilter(searchFilter);
     }
 
     @Transactional

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/controller/GrowthHistoryController.java
@@ -3,7 +3,7 @@ package com.codeit.donggrina.domain.growth_history.controller;
 import com.codeit.donggrina.common.api.ApiResponse;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
-import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.service.GrowthHistoryService;

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.codeit.donggrina.domain.growth_history.repository;
 
-import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import java.time.LocalDate;

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
@@ -4,7 +4,7 @@ import static com.codeit.donggrina.domain.growth_history.entity.QGrowthHistory.g
 import static com.codeit.donggrina.domain.member.entity.QMember.member;
 import static com.codeit.donggrina.domain.pet.entity.QPet.pet;
 
-import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -4,7 +4,7 @@ import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
-import com.codeit.donggrina.domain.growth_history.dto.request.SearchFilter;
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;


### PR DESCRIPTION
## Issue Link
close #94 

## To Reviewers
**성장기록 날짜별 조회 시 그룹 id 추가**

**일정 검색 기능**
검색 필터는 성장기록 검색 시 사용한 필터와 동일합니다. -> 이것 때문에 SearchFilter 클래스를 common 패키지로 이동시켰습니다.

## Reference
