### PR TITLE
불필요한 도커 이미지 삭제

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,3 +57,5 @@ jobs:
             docker rm donggrina || true
             docker pull ${{ steps.login-ecr.outputs.registry }}/donggrina:latest
             docker run -d --name donggrina -p 8080:8080 ${{ steps.login-ecr.outputs.registry }}/donggrina:latest
+            LATEST_IMAGE_ID=$(docker images -q ${{ steps.login-ecr.outputs.registry }}/donggrina:latest)
+            docker rmi $(docker images -q | grep -v $LATEST_IMAGE_ID) || true


### PR DESCRIPTION
## Issue Link
close #100 

## To Reviewers
저장 공간 확보를 위해 최신 배포한 이미지만 남기고 나머지 불필요한 이미지(이전 배포에 사용됐던 이미지)를 삭제합니다.

## Reference
