### PR TITLE
로그인 한 유저가 소속된 그룹의 id 를 반환하는 기능 구현(상세조회 때 사용)

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -40,6 +40,18 @@ public class GroupController {
             .build();
     }
 
+    @GetMapping("/my/groups/id")
+    public ApiResponse<Long> getGroupId(
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        return ApiResponse.<Long>builder()
+            .code(HttpStatus.OK.value())
+            .message("가족(그룹) ID 조회 성공")
+            .data(groupService.getGroupId(memberId))
+            .build();
+    }
+
     @PostMapping("/my/groups")
     public ApiResponse<Long> append(@RequestBody @Validated GroupAppendRequest request,
         @AuthenticationPrincipal CustomOAuth2User user) {

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -39,6 +39,15 @@ public class GroupService {
         return groupRepository.findGroupDetail(groupId);
     }
 
+    public Long getGroupId(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        if (member.getGroup() == null) {
+            throw new IllegalArgumentException("그룹에 소속되어 있지 않습니다.");
+        }
+        return member.getGroup().getId();
+    }
+
     @Transactional
     public Long append(GroupAppendRequest request, Long userId) {
         // 그룹 이름으로 조회를 하고 중복된 그룹이 있다면 예외를 발생시킵니다.


### PR DESCRIPTION
## Issue Link
close #102 

## To Reviewers
로그인 한 유저의 id를 바탕으로 그룹을 조회하고 그룹의 id를 반환해줍니다.

## Reference
