### PR TITLE
일정의 memo 를 필수 입력 필드로 변경

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/dto/request/CalendarAppendRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/dto/request/CalendarAppendRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 public record CalendarAppendRequest(
     @NotBlank(message = "제목을 입력해주세요.")
     String title,
+    @NotBlank(message = "내용을 입력해주세요.")
     String memo,
     @NotBlank(message = "반려동물을 선택해주세요.")
     String petName,

--- a/src/main/java/com/codeit/donggrina/domain/calendar/dto/request/CalendarUpdateRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/dto/request/CalendarUpdateRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 public record CalendarUpdateRequest(
     @NotBlank(message = "제목을 입력해주세요.")
     String title,
+    @NotBlank(message = "내용을 입력해주세요.")
     String memo,
     @NotBlank(message = "반려동물을 선택해주세요.")
     String petName,


### PR DESCRIPTION
## Issue Link
close #105 

## To Reviewers
일정 등록할 때 memo(내용)도 필수 입력으로 한다고 해서 그 부분을 검증하는 유효성 검증 어노테이션을 추가하였습니다. 일정 수정하는 부분도 동일하게 적용했습니다.
## Reference
