### PR TITLE
fix: CORS 오리진에 localhost:3000 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/common/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/donggrina/common/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
             .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
                 CorsConfiguration configuration = new CorsConfiguration();
                 configuration.setAllowedOrigins(
-                    Collections.singletonList("https://www.donggrina.click"));
+                    Arrays.asList("https://www.donggrina.click", "http://localhost:3000"));
                 configuration.setAllowedMethods(
                     Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS"));
                 configuration.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## Issue Link
close #107 

## To Reviewers
SecurityConfig 에서 localhost:3000 을 CORS 오리진에 추가해줬습니다.

프론트엔드 분들이 개발을 진행해야 할 것 같아서 바로 머지하도록 하겠습니다.
## Reference
