### PR TITLE
다이어리 등록 오류 수정

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/diary/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/dto/request/DiaryCreateRequest.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record DiaryCreateRequest(
     @NotNull(message = "반려동물을 선택해주세요.")
     List<Long> pets,
+    @NotNull(message = "이미지를 null로 보내면 안됩니다.")
     List<Long> images,
     @NotNull(message = "내용을 입력해주세요")
     String content,

--- a/src/main/java/com/codeit/donggrina/domain/diary/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/dto/request/DiaryCreateRequest.java
@@ -7,7 +7,6 @@ import java.util.List;
 public record DiaryCreateRequest(
     @NotNull(message = "반려동물을 선택해주세요.")
     List<Long> pets,
-    @NotNull(message = "이미지를 null로 보내면 안됩니다.")
     List<Long> images,
     @NotNull(message = "내용을 입력해주세요")
     String content,

--- a/src/main/java/com/codeit/donggrina/domain/diary/entity/Diary.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/entity/Diary.java
@@ -50,13 +50,14 @@ public class Diary extends Timestamp {
 
     @Builder
     private Diary(Long id, String content, String weather, boolean isShared, LocalDate date,
-        Member member, List<Pet> pets, List<DiaryImage> diaryImages) {
+        Member member, Group group, List<Pet> pets, List<DiaryImage> diaryImages) {
         this.id = id;
         this.content = content;
         this.weather = weather;
         this.isShared = isShared;
         this.date = date;
         this.member = member;
+        this.group = group;
         addDiaryPets(pets);
         linkDiaryImageToDiary(diaryImages);
     }

--- a/src/main/java/com/codeit/donggrina/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/service/DiaryService.java
@@ -48,6 +48,7 @@ public class DiaryService {
             .isShared(diaryCreateRequest.isShare())
             .diaryImages(images)
             .member(currentMember)
+            .group(currentMember.getGroup())
             .pets(pets)
             .date(diaryCreateRequest.date())
             .build();

--- a/src/main/java/com/codeit/donggrina/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/service/DiaryService.java
@@ -12,6 +12,7 @@ import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import com.codeit.donggrina.domain.pet.entity.Pet;
 import com.codeit.donggrina.domain.pet.repository.PetRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,11 +32,14 @@ public class DiaryService {
         Member currentMember = memberRepository.findById(memberId)
             .orElseThrow(RuntimeException::new);
 
-        List<DiaryImage> images = diaryCreateRequest.images().stream()
-            .map((imageId) ->
-                diaryImageRepository.findById(imageId).orElseThrow(RuntimeException::new))
-            .toList();
+        List<DiaryImage> images = new ArrayList<>();
+        if(diaryCreateRequest.images() != null) {
+            images = diaryCreateRequest.images().stream()
+                .map((imageId) ->
+                    diaryImageRepository.findById(imageId).orElseThrow(RuntimeException::new))
+                .toList();
 
+        }
         List<Pet> pets = diaryCreateRequest.pets().stream()
             .map((id) ->
                 petRepository.findById(id).orElseThrow(RuntimeException::new)


### PR DESCRIPTION
## Issue Link
close #114

## To Reviewers
다이어리 생성 시 그룹 정보가 저장되지 않는 오류를 수정했습니다
~다이어리 생싱 시 받는 image id list가 Null이 넘어오지 않도록 설정했습니다. 이미지가 없으면 빈 리스트를 넘겨야 합니다.~
프론트에서 정한대로 Null 값을 허용했고 Null이 넘어올 경우 빈 리스트가 저장되도록 수정했습니다.

## Reference
