### PR TITLE
일정을 date 별로 조회할 때 완료여부 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/dto/response/CalendarListResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/dto/response/CalendarListResponse.java
@@ -13,7 +13,8 @@ public record CalendarListResponse(
     LocalDateTime dateTime,
     String memberProfileImageUrl,
     String nickname,
-    String petProfileImageUrl
+    String petProfileImageUrl,
+    boolean isFinished
 ) {
 
     public static CalendarListResponse from(Calendar calendar) {
@@ -25,6 +26,7 @@ public record CalendarListResponse(
             .memberProfileImageUrl(calendar.getMember().getProfileImage().getUrl())
             .nickname(calendar.getMember().getNickname())
             .petProfileImageUrl(calendar.getPet().getProfileImage().getUrl())
+            .isFinished(calendar.isFinished())
             .build();
     }
 


### PR DESCRIPTION
## Issue Link
close #117 

## To Reviewers
일정 date 별로 조회할 때 완료여부 값도 보내주도록 추가했습니다.
## Reference
