### PR TITLE
일정, 성장기록 수정 또는 삭제 시 방장은 모두 가능하도록 변경 + 코드 리팩토링

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -1,5 +1,6 @@
 package com.codeit.donggrina.domain.calendar.service;
 
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarAppendRequest;
 import com.codeit.donggrina.domain.calendar.dto.request.CalendarUpdateRequest;
 import com.codeit.donggrina.domain.calendar.dto.response.CalendarDailyCountResponse;
@@ -8,8 +9,6 @@ import com.codeit.donggrina.domain.calendar.dto.response.CalendarListResponse;
 import com.codeit.donggrina.domain.calendar.entity.Calendar;
 import com.codeit.donggrina.domain.calendar.repository.CalendarRepository;
 import com.codeit.donggrina.domain.group.entity.Group;
-import com.codeit.donggrina.domain.group.repository.GroupRepository;
-import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import com.codeit.donggrina.domain.pet.entity.Pet;
@@ -17,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,12 +27,15 @@ public class CalendarService {
 
     private final CalendarRepository calendarRepository;
     private final MemberRepository memberRepository;
-    private final GroupRepository groupRepository;
 
-    public List<CalendarDailyCountResponse> getDailyCountByMonth(Long memberId, YearMonth yearMonth) {
-        Member member = memberRepository.findById(memberId)
+    public List<CalendarDailyCountResponse> getDailyCountByMonth(Long memberId,
+        YearMonth yearMonth) {
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Long groupId = member.getGroup().getId();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+        Long groupId = group.getId();
 
         if (yearMonth == null) {
             yearMonth = YearMonth.now();
@@ -41,9 +44,13 @@ public class CalendarService {
     }
 
     public List<CalendarListResponse> getDayListByDate(Long memberId, LocalDate date) {
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Long groupId = member.getGroup().getId();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+        Long groupId = group.getId();
+
         if (date == null) {
             date = LocalDate.now();
         }
@@ -82,15 +89,11 @@ public class CalendarService {
 
     @Transactional
     public Long append(Long memberId, CalendarAppendRequest request) {
-        // 로그인 한 사용자를 데이터베이스에서 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-
-        // 사용자가 속한 그룹을 조회하고, 그룹에 속한 반려동물 중 일정을 등록하려는 반려동물을 찾습니다.
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group = member.getGroup();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
 
         // 그룹에 속한 반려동물들 중에서 사용자가 선택한 반려동물을 조회합니다.
         Pet pet = group.getPets().stream()
@@ -112,15 +115,13 @@ public class CalendarService {
 
     @Transactional
     public void update(Long memberId, Long calendarId, CalendarUpdateRequest request) {
-        // 로그인 한 사용자를 데이터베이스에서 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
 
-        // 사용자가 속한 그룹을 조회하고, 그룹에 속한 반려동물 중 일정을 등록하려는 반려동물을 찾습니다.
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group = member.getGroup();
+        // 그룹의 방장의 이름을 조회합니다.
         String groupCreator = group.getCreator();
 
         // 그룹에 속한 반려동물들 중에서 사용자가 선택한 반려동물을 조회합니다.
@@ -132,7 +133,8 @@ public class CalendarService {
         // 일정을 조회하고 수정합니다. 본인이 작성한 일정이 아니거나 그룹 방장이 아니라면 예외를 발생시킵니다.
         Calendar calendar = calendarRepository.findById(calendarId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 일정입니다."));
-        if (!calendar.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
+        if (!calendar.getMember().getId().equals(memberId) && !member.getUsername()
+            .equals(groupCreator)) {
             throw new IllegalArgumentException("본인이 작성한 일정만 수정할 수 있습니다.");
         }
         calendar.update(request, pet);
@@ -140,19 +142,18 @@ public class CalendarService {
 
     @Transactional
     public void updateCompletionState(Long memberId, Long calendarId) {
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        // 사용자가 속한 그룹을 조회하고, 그룹의 방장의 이름을 조회합니다.
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group = member.getGroup();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
         String groupCreator = group.getCreator();
 
         // 일정을 조회하고 완료 여부를 수정합니다. 본인이 작성한 일정이 아니거나 방장이 아니라면 예외를 발생시킵니다.
         Calendar calendar = calendarRepository.findById(calendarId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 일정입니다."));
-        if (!calendar.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
+        if (!calendar.getMember().getId().equals(memberId) && !member.getUsername()
+            .equals(groupCreator)) {
             throw new IllegalArgumentException("본인이 작성한 일정만 완료 처리 할 수 있습니다.");
         }
         calendar.updateCompletion();
@@ -160,19 +161,18 @@ public class CalendarService {
 
     @Transactional
     public void delete(Long memberId, Long calendarId) {
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        // 사용자가 속한 그룹을 조회하고, 그룹의 방장의 이름을 조회합니다.
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group = member.getGroup();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
         String groupCreator = group.getCreator();
 
         // 일정을 조회하고 삭제합니다. 본인이 작성한 일정이 아니거나 방장이 아니라면 예외를 발생시킵니다.
         Calendar calendar = calendarRepository.findById(calendarId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 일정입니다."));
-        if (!calendar.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
+        if (!calendar.getMember().getId().equals(memberId) && !member.getUsername()
+            .equals(groupCreator)) {
             throw new IllegalArgumentException("본인이 작성한 일정만 삭제할 수 있습니다.");
         }
         calendarRepository.delete(calendar);

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -1,10 +1,9 @@
 package com.codeit.donggrina.domain.growth_history.service;
 
+import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.group.entity.Group;
-import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryAppendRequest;
 import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdateRequest;
-import com.codeit.donggrina.common.api.SearchFilter;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryDetailResponse;
 import com.codeit.donggrina.domain.growth_history.dto.response.GrowthHistoryListResponse;
 import com.codeit.donggrina.domain.growth_history.entity.GrowthHistory;
@@ -15,6 +14,7 @@ import com.codeit.donggrina.domain.pet.entity.Pet;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,18 +24,20 @@ public class GrowthHistoryService {
 
     private final GrowthHistoryRepository growthHistoryRepository;
     private final MemberRepository memberRepository;
-    private final GroupRepository groupRepository;
 
     public List<GrowthHistoryListResponse> getByDate(Long memberId, LocalDate date) {
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Long groupId = member.getGroup().getId();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+        Long groupId = group.getId();
         return growthHistoryRepository.findGrowthHistoryDetailByDate(groupId, date)
             .stream()
             .map(growthHistory -> {
                 boolean isMine = growthHistory.getMember().equals(member);
                 return GrowthHistoryListResponse.from(growthHistory, isMine);
-                })
+            })
             .toList();
     }
 
@@ -61,13 +63,11 @@ public class GrowthHistoryService {
 
     @Transactional
     public Long append(Long memberId, GrowthHistoryAppendRequest request) {
-        // 로그인 한 사용자를 조회하고, 해당 사용자가 속한 그룹과 그룹에 속한 반려동물을 fetch Join 으로 함께 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group= member.getGroup();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
 
         // 그룹에 속한 반려동물들 중에서 사용자가 선택한 반려동물을 조회합니다.
         Pet pet = group.getPets().stream()
@@ -96,19 +96,18 @@ public class GrowthHistoryService {
 
     @Transactional
     public void update(Long memberId, Long growthId, GrowthHistoryUpdateRequest request) {
-        // 로그인 한 사용자를 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group= member.getGroup();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
         String groupCreator = group.getCreator();
 
         // GrowthHistory를 조회하고 수정합니다. 본인이 작성한 성장기록이 아니고 방장도 아니라면 예외가 발생합니다.
         GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
-        if (!growthHistory.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
+        if (!growthHistory.getMember().getId().equals(memberId) && !member.getUsername()
+            .equals(groupCreator)) {
             throw new IllegalArgumentException("본인의 성장기록만 수정할 수 있습니다.");
         }
         growthHistory.update(request);
@@ -116,19 +115,18 @@ public class GrowthHistoryService {
 
     @Transactional
     public void delete(Long memberId, Long growthId) {
-        // 로그인 한 사용자를 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        // 로그인 한 사용자와 소속 그룹을 데이터베이스에서 조회합니다. 멤버가 없거나 멤버가 그룹에 속해 있지 않다면 예외를 발생시킵니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
-        }
-        Group group= member.getGroup();
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
         String groupCreator = group.getCreator();
 
         // GrowthHistory를 조회하고 삭제합니다. 본인이 작성한 성장기록이 아니고 방장도 아니라면 예외가 발생합니다.
         GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
-        if (!growthHistory.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
+        if (!growthHistory.getMember().getId().equals(memberId) && !member.getUsername()
+            .equals(groupCreator)) {
             throw new IllegalArgumentException("본인의 성장기록만 삭제할 수 있습니다.");
         }
         growthHistoryRepository.delete(growthHistory);

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -67,9 +67,7 @@ public class GrowthHistoryService {
         if (member.getGroup() == null) {
             throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
         }
-        Long groupId = member.getGroup().getId();
-        Group group = groupRepository.findWithPets(groupId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+        Group group= member.getGroup();
 
         // 그룹에 속한 반려동물들 중에서 사용자가 선택한 반려동물을 조회합니다.
         Pet pet = group.getPets().stream()
@@ -99,13 +97,18 @@ public class GrowthHistoryService {
     @Transactional
     public void update(Long memberId, Long growthId, GrowthHistoryUpdateRequest request) {
         // 로그인 한 사용자를 조회합니다.
-        memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        if (member.getGroup() == null) {
+            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
+        }
+        Group group= member.getGroup();
+        String groupCreator = group.getCreator();
 
-        // GrowthHistory를 조회하고 수정합니다.
+        // GrowthHistory를 조회하고 수정합니다. 본인이 작성한 성장기록이 아니고 방장도 아니라면 예외가 발생합니다.
         GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
-        if (!growthHistory.getMember().getId().equals(memberId)) {
+        if (!growthHistory.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
             throw new IllegalArgumentException("본인의 성장기록만 수정할 수 있습니다.");
         }
         growthHistory.update(request);
@@ -114,13 +117,18 @@ public class GrowthHistoryService {
     @Transactional
     public void delete(Long memberId, Long growthId) {
         // 로그인 한 사용자를 조회합니다.
-        memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        if (member.getGroup() == null) {
+            throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
+        }
+        Group group= member.getGroup();
+        String groupCreator = group.getCreator();
 
-        // GrowthHistory를 조회하고 삭제합니다.
+        // GrowthHistory를 조회하고 삭제합니다. 본인이 작성한 성장기록이 아니고 방장도 아니라면 예외가 발생합니다.
         GrowthHistory growthHistory = growthHistoryRepository.findById(growthId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성장기록입니다."));
-        if (!growthHistory.getMember().getId().equals(memberId)) {
+        if (!growthHistory.getMember().getId().equals(memberId) && !member.getUsername().equals(groupCreator)) {
             throw new IllegalArgumentException("본인의 성장기록만 삭제할 수 있습니다.");
         }
         growthHistoryRepository.delete(growthHistory);

--- a/src/main/java/com/codeit/donggrina/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/repository/MemberRepository.java
@@ -18,4 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("select m from Member m join fetch m.group join fetch m.profileImage where m.id = :memberId")
     Optional<Member> findByIdWithGroupAndProfileImage(Long memberId);
 
+    @Query("select m from Member m join fetch m.group where m.id = :memberId")
+    Optional<Member> findByIdWithGroup(Long memberId);
+
 }


### PR DESCRIPTION
## Issue Link
close #124 

## To Reviewers
일정과 성장기록을 수정 또는 삭제할 때 방장은 자신이 작성한 것이 아니더라도 가능하도록 수정했습니다.

멤버를 조회할 때 그룹을 함께 fetch join 으로 조회하도록 해서 쿼리를 한 번만 나가게 했습니다. Optional을 사용하는 방식으로 코드를 개선해봤습니다. 멤버와 그룹 조회하는 부분을 좀 신경써서 봐주시면 감사하겠습니당. 민우님 의견도 주시면 좋구요! 우선은 일정 부분만 이렇게 해 봤는데 괜찮은 것 같으면 성장기록 쪽도 이렇게 다 리팩터링 하겠습니당
## Reference
