### PR TITLE
댓글, 대댓글 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/controller/CommentController.java
@@ -1,0 +1,35 @@
+package com.codeit.donggrina.domain.comment.controller;
+
+import com.codeit.donggrina.common.api.ApiResponse;
+import com.codeit.donggrina.domain.comment.dto.request.CommentAppendRequest;
+import com.codeit.donggrina.domain.comment.service.CommentService;
+import com.codeit.donggrina.domain.member.dto.request.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/comments/{diaryId}")
+    public ApiResponse<Long> append(
+        @PathVariable Long diaryId,
+        @RequestBody @Validated CommentAppendRequest request,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        return ApiResponse.<Long>builder()
+            .code(HttpStatus.OK.value())
+            .message("댓글 작성 성공")
+            .data(commentService.append(diaryId, request, memberId))
+            .build();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/comment/dto/request/CommentAppendRequest.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/dto/request/CommentAppendRequest.java
@@ -1,0 +1,11 @@
+package com.codeit.donggrina.domain.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentAppendRequest(
+    @NotBlank(message = "내용을 입력해주세요.")
+    String content,
+    Long parentCommentId
+) {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/entity/Comment.java
@@ -1,0 +1,73 @@
+package com.codeit.donggrina.domain.comment.entity;
+
+import com.codeit.donggrina.common.Timestamp;
+import com.codeit.donggrina.domain.diary.entity.Diary;
+import com.codeit.donggrina.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends Timestamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isDeleted;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_member_comment"))
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id", foreignKey = @ForeignKey(name = "fk_parent_comment"))
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    private final List<Comment> children = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false, foreignKey = @ForeignKey(name = "fk_diary_comment"))
+    private Diary diary;
+
+    @Builder
+    private Comment(String content, Member member, Diary diary) {
+        this.date = LocalDate.now();
+        this.content = content;
+        this.member = member;
+        this.diary = diary;
+    }
+
+    public void updateParent(Comment parentComment) {
+        this.parent = parentComment;
+    }
+
+    public void addChildComment(Comment childComment) {
+        this.children.add(childComment);
+        childComment.updateParent(this);
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.codeit.donggrina.domain.comment.repository;
+
+import com.codeit.donggrina.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
@@ -1,0 +1,46 @@
+package com.codeit.donggrina.domain.comment.service;
+
+import com.codeit.donggrina.domain.comment.dto.request.CommentAppendRequest;
+import com.codeit.donggrina.domain.comment.entity.Comment;
+import com.codeit.donggrina.domain.comment.repository.CommentRepository;
+import com.codeit.donggrina.domain.diary.entity.Diary;
+import com.codeit.donggrina.domain.diary.repository.DiaryRepository;
+import com.codeit.donggrina.domain.member.entity.Member;
+import com.codeit.donggrina.domain.member.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long append(Long diaryId,CommentAppendRequest request, Long memberId) {
+        // 댓글을 작성하는 로그인 멤버와 댓글이 달릴 다이어리를 조회합니다.
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Diary diary = diaryRepository.findById(diaryId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 다이어리입니다."));
+
+        // 댓글을 생성합니다.
+        Comment comment = Comment.builder()
+            .member(member)
+            .diary(diary)
+            .content(request.content())
+            .build();
+
+        // 부모 댓글이 있는 경우, 부모 댓글에 자식 댓글을 추가합니다.
+        Optional.ofNullable(request.parentCommentId())
+            .map(parentId -> commentRepository.findById(parentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부모 댓글입니다.")))
+            .ifPresent(parentComment -> parentComment.addChildComment(comment));
+
+        return commentRepository.save(comment).getId();
+    }
+}

--- a/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
@@ -35,6 +35,9 @@ public class CommentService {
             .content(request.content())
             .build();
 
+        // 다이어리에 있는 댓글 리스트에 댓글을 추가해줍니다.
+        diary.addComment(comment);
+
         // 부모 댓글이 있는 경우, 부모 댓글에 자식 댓글을 추가합니다.
         Optional.ofNullable(request.parentCommentId())
             .map(parentId -> commentRepository.findById(parentId)

--- a/src/main/java/com/codeit/donggrina/domain/diary/entity/Diary.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/entity/Diary.java
@@ -21,17 +21,14 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Slf4j
 public class Diary extends Timestamp {
 
     @Id
@@ -103,8 +100,8 @@ public class Diary extends Timestamp {
     }
 
     private void unLinkDiaryImageToDiary(List<DiaryImage> diaryImages) {
-        for(DiaryImage diaryImage : this.diaryImages) {
-            if(!diaryImages.contains(diaryImage)) {
+        for (DiaryImage diaryImage : this.diaryImages) {
+            if (!diaryImages.contains(diaryImage)) {
                 diaryImage.unLinkDiary();
             }
         }
@@ -124,7 +121,8 @@ public class Diary extends Timestamp {
         diaryPets.clear();
         addDiaryPets(pets);
     }
-    private void updateImages(List<DiaryImage> images){
+
+    private void updateImages(List<DiaryImage> images) {
         linkDiaryImageToDiary(images);
         unLinkDiaryImageToDiary(images);
     }

--- a/src/main/java/com/codeit/donggrina/domain/diary/entity/Diary.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/entity/Diary.java
@@ -1,6 +1,7 @@
 package com.codeit.donggrina.domain.diary.entity;
 
 import com.codeit.donggrina.common.Timestamp;
+import com.codeit.donggrina.domain.comment.entity.Comment;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.pet.entity.Pet;
@@ -25,10 +26,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Diary extends Timestamp {
 
     @Id
@@ -64,6 +67,9 @@ public class Diary extends Timestamp {
 
     @Column(nullable = false)
     private int heartCount;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "diary", cascade = CascadeType.REMOVE)
+    private final List<Comment> comments = new ArrayList<>();
 
     @Builder
     private Diary(Long id, String content, String weather, boolean isShared, LocalDate date,
@@ -121,6 +127,10 @@ public class Diary extends Timestamp {
     private void updateImages(List<DiaryImage> images){
         linkDiaryImageToDiary(images);
         unLinkDiaryImageToDiary(images);
+    }
+
+    public void addComment(Comment comment) {
+        this.comments.add(comment);
     }
 
 }


### PR DESCRIPTION
## Issue Link
close #139 

## To Reviewers
댓글, 대댓글 추가 기능입니다.

요청을 보낼 때 parentCommentId 가 null 이면 그냥 댓글, parentCommentId 가 있으면 그 댓글의 대댓글로 작성되고 DB에 저장됩니다.

다이어리 조회 시 댓글 리스트 불러오는 것과 다이어리 삭제 시 하위의 댓글, 대댓글을 한 번에 다 삭제시키게 하려고 양방향 연관관계를 걸어봤는데 맞게 잘 걸었는지 확인해주시면 감사하겠습니다.
## Reference
