### PR TITLE
댓글, 대댓글 삭제 기능

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -46,6 +47,32 @@ public class CommentController {
         return ApiResponse.<Void>builder()
             .code(HttpStatus.OK.value())
             .message("댓글 수정 성공")
+            .build();
+    }
+
+    @DeleteMapping("/comments/parent/{commentId}")
+    public ApiResponse<Void> deleteParentComment(
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        commentService.deleteParentComment(commentId, memberId);
+        return ApiResponse.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .message("부모 댓글 삭제 성공")
+            .build();
+    }
+
+    @DeleteMapping("/comments/child/{commentId}")
+    public ApiResponse<Void> deleteChildComment(
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal CustomOAuth2User member
+    ) {
+        Long memberId = member.getMemberId();
+        commentService.deleteChildComment(commentId, memberId);
+        return ApiResponse.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .message("대댓글 삭제 성공")
             .build();
     }
 }

--- a/src/main/java/com/codeit/donggrina/domain/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/entity/Comment.java
@@ -74,4 +74,8 @@ public class Comment extends Timestamp {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void updateIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.codeit.donggrina.domain.comment.entity.Comment;
 import com.codeit.donggrina.domain.comment.repository.CommentRepository;
 import com.codeit.donggrina.domain.diary.entity.Diary;
 import com.codeit.donggrina.domain.diary.repository.DiaryRepository;
+import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.member.repository.MemberRepository;
 import java.util.Optional;
@@ -24,7 +25,13 @@ public class CommentService {
     @Transactional
     public Long append(Long diaryId,CommentAppendRequest request, Long memberId) {
         // 댓글을 작성하는 로그인 멤버와 댓글이 달릴 다이어리를 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
+            .map(m -> {
+                if (m.getGroup() == null) {
+                    throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
+                }
+                return m;
+            })
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         Diary diary = diaryRepository.findById(diaryId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 다이어리입니다."));
@@ -61,5 +68,59 @@ public class CommentService {
             throw new IllegalArgumentException("본인의 댓글만 수정할 수 있습니다.");
         }
         comment.updateContent(request.content());
+    }
+
+    @Transactional
+    public void deleteParentComment(Long commentId, Long memberId) {
+        // 댓글을 삭제하는 로그인 멤버와 삭제할 댓글을 조회합니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+        String groupCreator = group.getCreator();
+
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        // 댓글을 삭제합니다. 댓글을 작성한 사람이 아니고 방장도 아니라면 예외를 발생시킵니다.
+        if (!comment.getMember().equals(member) && !member.getUsername().equals(groupCreator)) {
+            throw new IllegalArgumentException("본인의 댓글만 삭제할 수 있습니다.");
+        }
+
+        // 대댓글이 하나도 달려있지 않은 댓글은 바로 삭제 합니다.
+        if (comment.getChildren().isEmpty()) {
+            commentRepository.delete(comment);
+        } else {
+            if (member.getUsername().equals(groupCreator)) {
+                // 그룹의 생성자는 대댓글이 달린 댓글을 삭제할 수 있습니다. 이 경우에 대댓글도 함께 삭제됩니다.
+                commentRepository.deleteAll(comment.getChildren());
+                commentRepository.delete(comment);
+            } else {
+                // 그룹의 생성자가 아니라면 대댓글이 달린 댓글은 soft delete 됩니다. isDeleted 가 true 로 바뀌고 댓글 내용이 변경됩니다.
+                comment.updateIsDeleted(true);
+                comment.updateContent("삭제된 댓글입니다.");
+            }
+        }
+    }
+
+    @Transactional
+    public void deleteChildComment(Long commentId, Long memberId) {
+        // 댓글을 삭제하는 로그인 멤버와 삭제할 대댓글을 조회합니다.
+        Member member = memberRepository.findByIdWithGroup(memberId)
+            .map(m -> {
+                if (m.getGroup() == null) {
+                    throw new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다.");
+                }
+                return m;
+            })
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        // 대댓글을 삭제합니다. 대댓글을 작성한 사람이 아니라면 예외를 발생시킵니다.
+        if (!comment.getMember().equals(member)) {
+            throw new IllegalArgumentException("본인의 댓글만 삭제할 수 있습니다.");
+        }
+        commentRepository.delete(comment);
     }
 }


### PR DESCRIPTION
## Issue Link
close #145 

## To Reviewers
댓글, 대댓글 삭제 기능입니다.

- 대댓글은 바로 삭제 가능합니다. 작성자만 삭제 가능합니다.
- 댓글은 대댓글이 달려있지 않다면 바로 삭제가 가능합니다.
  
대댓글이 달려있다면 다음과 같이 동작합니다.
- 방장은 대댓글이 달려있는 댓글이라도 바로 삭제 가능합니다. 이 때 대댓글도 같이 삭제됩니다.
- 일반 유저가 대댓글이 달려있는 댓글을 삭제하면 soft delete 가 되고 문구가 수정됩니다.

## Reference
