### PR TITLE
OAuth2 로그인 redirect url 수정

### DIFF
--- a/src/main/java/com/codeit/donggrina/common/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/donggrina/common/config/SecurityConfig.java
@@ -59,8 +59,8 @@ public class SecurityConfig {
                 .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
             )
             .oauth2Login((oauth2) -> oauth2
-                .redirectionEndpoint(endpoint -> endpoint.baseUri("/members/login/kakao"))
-                .redirectionEndpoint(endpoint -> endpoint.baseUri("/members/login/google"))
+//                .redirectionEndpoint(endpoint -> endpoint.baseUri("/members/login/kakao"))
+                .redirectionEndpoint(endpoint -> endpoint.baseUri("/members/login"))
                 .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                     .userService(customOAuth2UserService))
                 .successHandler(oAuth2LoginSuccessHandler)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,7 +12,7 @@ spring:
     password: ${DONGGRINA_LOCAL_DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -36,7 +36,7 @@ spring:
           kakao:
             client-id: ${OAUTH2_KAKAO_CLIENT_ID}
             client-secret: ${OAUTH2_KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/members/login/kakao
+            redirect-uri: http://localhost:8080/members/login
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:
@@ -46,7 +46,7 @@ spring:
           google:
             client-id: ${OAUTH2_GOOGLE_CLIENT_ID}
             client-secret: ${OAUTH2_GOOGLE_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/members/login/google
+            redirect-uri: http://localhost:8080/members/login
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:


### PR DESCRIPTION
## Issue Link
hotfix 입니다.

## To Reviewers
로그인 시 redirect url을 하나만 설정할 수 있어 카카오, 구글 둘 다 통일했습니다

## Reference
