### PR TITLE
조회 관련 API 로직에 사용자가 그룹에 소속돼 있는지 검증하는 예외 처리 로직 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -64,8 +64,10 @@ public class CalendarService {
 
     public CalendarDetailResponse getDetail(Long calendarId, Long memberId) {
         // 로그인 한 유저를 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
 
         // 일정을 조회하고, 조회한 일정이 로그인한 유저가 작성한 일정인지 확인합니다.
         Calendar findCalendar = calendarRepository.getDetail(calendarId);
@@ -75,8 +77,11 @@ public class CalendarService {
     }
 
     public List<CalendarListResponse> search(SearchFilter searchFilter, Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+
         return calendarRepository.findBySearchFilter(searchFilter)
             .stream()
             .map(calendar -> {

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -9,10 +9,7 @@ import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.repository.GroupRepository;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.member.repository.MemberRepository;
-import com.codeit.donggrina.domain.pet.dto.request.PetAddRequest;
-import com.codeit.donggrina.domain.pet.dto.response.PetFindListResponse;
-import com.codeit.donggrina.domain.pet.entity.Pet;
-import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -31,21 +28,21 @@ public class GroupService {
 
     @Transactional(readOnly = true)
     public GroupDetailResponse getDetail(Long userId) {
-        Member member = memberRepository.findById(userId)
+        Member member = memberRepository.findByIdWithGroup(userId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 소속되어 있지 않습니다.");
-        }
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+
         Long groupId = member.getGroup().getId();
         return groupRepository.findGroupDetail(groupId);
     }
 
     public GroupCodeResponse getGroupCode(Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if (member.getGroup() == null) {
-            throw new IllegalArgumentException("그룹에 소속되어 있지 않습니다.");
-        }
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+
         Long groupId = member.getGroup().getId();
         String invitationCode = member.getGroup().getCode();
         return GroupCodeResponse.builder()

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -42,16 +42,22 @@ public class GrowthHistoryService {
     }
 
     public GrowthHistoryDetailResponse getDetail(Long growthId, Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+
         GrowthHistory growthHistory = growthHistoryRepository.findGrowthHistoryDetail(growthId);
         boolean isMine = growthHistory.getMember().equals(member);
         return GrowthHistoryDetailResponse.from(growthHistory, isMine);
     }
 
     public List<GrowthHistoryListResponse> search(SearchFilter searchFilter, Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+
         return growthHistoryRepository.findGrowthHistoryBySearchFilter(searchFilter)
             .stream()
             .map(growthHistory -> {


### PR DESCRIPTION
## Issue Link
close #196 

## To Reviewers
- Calendar
- Group
- GrowthHistory

세 개의 도메인에 대해서 조회를 하는 API 로직에 사용자가 그룹에 속해있는지 여부를 검증하는 예외 처리 로직을 추가했습니다.

조회 API 말고 다른 쓰기 작업 API 에 대해서는 이미 예외처리가 돼 있는 부분들이 있어서 동일하게 해줘야 하는지 고민이 되는데 민우님 생각은 어떠신지 의견 남겨주시면 감사하겠습니다.
## Reference
