### PR TITLE
일정 & 성장기록 검색 시 groupId 조건 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepository.java
@@ -15,5 +15,5 @@ public interface CustomCalendarRepository {
 
     Calendar getDetail(Long calendarId);
 
-    List<Calendar> findBySearchFilter(SearchFilter searchFilter);
+    List<Calendar> findBySearchFilter(Long groupId, SearchFilter searchFilter);
 }

--- a/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/repository/CustomCalendarRepositoryImpl.java
@@ -86,7 +86,7 @@ public class CustomCalendarRepositoryImpl implements CustomCalendarRepository {
     }
 
     @Override
-    public List<Calendar> findBySearchFilter(SearchFilter searchFilter) {
+    public List<Calendar> findBySearchFilter(Long groupId, SearchFilter searchFilter) {
         return queryFactory
             .selectFrom(calendar)
             .leftJoin(calendar.member, member).fetchJoin()
@@ -96,7 +96,8 @@ public class CustomCalendarRepositoryImpl implements CustomCalendarRepository {
             .where(
                 containsKeyword(searchFilter.keyword()),
                 inPetNames(searchFilter.petNames()),
-                inWriterNames(searchFilter.writerNames())
+                inWriterNames(searchFilter.writerNames()),
+                calendar.member.group.id.eq(groupId)
             )
             .orderBy(calendar.id.desc())
             .fetch();

--- a/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/service/CalendarService.java
@@ -79,10 +79,11 @@ public class CalendarService {
     public List<CalendarListResponse> search(SearchFilter searchFilter, Long memberId) {
         Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Optional.ofNullable(member.getGroup())
+        Group group = Optional.ofNullable(member.getGroup())
             .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+        Long groupId = group.getId();
 
-        return calendarRepository.findBySearchFilter(searchFilter)
+        return calendarRepository.findBySearchFilter(groupId, searchFilter)
             .stream()
             .map(calendar -> {
                 boolean isMine = calendar.getMember().equals(member);

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepository.java
@@ -11,5 +11,5 @@ public interface CustomGrowthHistoryRepository {
 
     GrowthHistory findGrowthHistoryDetail(Long growthId);
 
-    List<GrowthHistory> findGrowthHistoryBySearchFilter(SearchFilter searchFilter);
+    List<GrowthHistory> findGrowthHistoryBySearchFilter(Long groupId, SearchFilter searchFilter);
 }

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/repository/CustomGrowthHistoryRepositoryImpl.java
@@ -54,6 +54,7 @@ public class CustomGrowthHistoryRepositoryImpl implements CustomGrowthHistoryRep
 
     @Override
     public List<GrowthHistory> findGrowthHistoryBySearchFilter(
+        Long groupId,
         SearchFilter searchFilter) {
         return queryFactory
             .selectFrom(growthHistory)
@@ -64,7 +65,8 @@ public class CustomGrowthHistoryRepositoryImpl implements CustomGrowthHistoryRep
             .where(
                 containsKeyword(searchFilter.keyword()),
                 inPetNames(searchFilter.petNames()),
-                inWriterNames(searchFilter.writerNames())
+                inWriterNames(searchFilter.writerNames()),
+                member.group.id.eq(groupId)
             )
             .orderBy(growthHistory.id.desc())
             .fetch();

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/service/GrowthHistoryService.java
@@ -55,10 +55,11 @@ public class GrowthHistoryService {
     public List<GrowthHistoryListResponse> search(SearchFilter searchFilter, Long memberId) {
         Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Optional.ofNullable(member.getGroup())
+        Group group = Optional.ofNullable(member.getGroup())
             .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
+        Long groupId = group.getId();
 
-        return growthHistoryRepository.findGrowthHistoryBySearchFilter(searchFilter)
+        return growthHistoryRepository.findGrowthHistoryBySearchFilter(groupId, searchFilter)
             .stream()
             .map(growthHistory -> {
                 boolean isMine = growthHistory.getMember().equals(member);


### PR DESCRIPTION
## Issue Link
close #201 

## To Reviewers
일정과 성장기록 검색 시 그룹 id 조건을 추가하여 사용자가 소속된 그룹의 일정과 성장기록만 조회되도록 수정했습니다.
## Reference
