### PR TITLE
댓글, 그룹 쓰기 작업에서 사용자 그룹 소속 여부 검증 예외처리 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/donggrina/domain/comment/service/CommentService.java
@@ -58,8 +58,11 @@ public class CommentService {
     @Transactional
     public void update(Long commentId, CommentUpdateRequest request, Long memberId) {
         // 댓글을 수정하는 로그인 멤버와 수정할 댓글을 조회합니다.
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdWithGroup(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다." ));
+
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
 

--- a/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/controller/GroupController.java
@@ -73,41 +73,38 @@ public class GroupController {
             .build();
     }
 
-    @PutMapping("/my/groups/{groupId}")
+    @PutMapping("/my/groups")
     public ApiResponse<Void> update(
-        @PathVariable Long groupId,
         @RequestBody @Validated GroupUpdateRequest request,
         @AuthenticationPrincipal CustomOAuth2User user
     ) {
         Long userId = user.getMemberId();
-        groupService.update(groupId, request, userId);
+        groupService.update(request, userId);
         return ApiResponse.<Void>builder()
             .code(HttpStatus.OK.value())
             .message("가족(그룹) 정보 수정 성공")
             .build();
     }
 
-    @DeleteMapping("/my/groups/{groupId}")
+    @DeleteMapping("/my/groups")
     public ApiResponse<Void> delete(
-        @PathVariable Long groupId,
         @AuthenticationPrincipal CustomOAuth2User user
     ) {
         Long userId = user.getMemberId();
-        groupService.delete(groupId, userId);
+        groupService.delete(userId);
         return ApiResponse.<Void>builder()
             .code(HttpStatus.OK.value())
             .message("가족(그룹) 삭제 성공")
             .build();
     }
 
-    @PostMapping("/my/groups/{groupId}/members/{targetId}")
+    @PostMapping("/my/groups/members/{targetId}")
     public ApiResponse<Void> deleteMember(
         @PathVariable Long targetId,
-        @PathVariable Long groupId,
         @AuthenticationPrincipal CustomOAuth2User user
     ) {
         Long userId = user.getMemberId();
-        groupService.deleteMember(targetId, groupId, userId);
+        groupService.deleteMember(targetId, userId);
         return ApiResponse.<Void>builder()
             .code(HttpStatus.OK.value())
             .message("가족(그룹) 멤버 삭제 성공")

--- a/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/service/GroupService.java
@@ -93,11 +93,11 @@ public class GroupService {
     }
 
     @Transactional
-    public void update(Long groupId, GroupUpdateRequest request, Long userId) {
-        Member member = memberRepository.findById(userId)
+    public void update(GroupUpdateRequest request, Long userId) {
+        Member member = memberRepository.findByIdWithGroup(userId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Group group = groupRepository.findById(groupId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
 
         // 그룹의 생성자와 로그인한 사용자가 일치하는지 확인하고 일치하지 않으면 예외를 발생시킵니다.
         if (!group.getCreator().equals(member.getUsername())) {
@@ -109,11 +109,11 @@ public class GroupService {
     }
 
     @Transactional
-    public void delete(Long groupId, Long userId) {
-        Member member = memberRepository.findById(userId)
+    public void delete(Long userId) {
+        Member member = memberRepository.findByIdWithGroup(userId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Group group = groupRepository.findById(groupId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+        Group group = Optional.ofNullable(member.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
 
         // 그룹의 생성자가 아닌 경우에는 그룹을 삭제할 수 없습니다.
         if (!group.getCreator().equals(member.getUsername())) {
@@ -129,12 +129,12 @@ public class GroupService {
     }
 
     @Transactional
-    public void deleteMember(Long targetId, Long groupId, Long userId) {
+    public void deleteMember(Long targetId, Long userId) {
         // 그룹과 로그인 유저, 삭제 대상 유저를 조회합니다.
-        Group group = groupRepository.findById(groupId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
-        Member loginMember = memberRepository.findById(userId)
+        Member loginMember = memberRepository.findByIdWithGroup(userId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Group group = Optional.ofNullable(loginMember.getGroup())
+            .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않은 사용자입니다."));
         Member targetMember = memberRepository.findById(targetId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 


### PR DESCRIPTION
## Issue Link
close #204 

## To Reviewers
- 댓글 업데이트
- 그룹 업데이트
- 그룹 삭제
- 그룹 멤버 삭제

4가지 경우에 대해서 사용자가 그룹에 소속되어 있는지 여부를 검증하는 예외 처리 로직을 추가했습니다.

그룹 업데이트, 그룹 삭제, 그룹 멤버 삭제를 할 때 groupId 를 path variable 로 받아서 그룹을 조회하는 로직을 리팩토링 했습니다. 사용자를 조회할 때 그룹을 fetch join 으로 조회하기 때문에 그룹을 조회할 필요가 없어서 이렇게 변경했습니다. (어차피 로그인 하고 요청을 보낸 멤버의 그룹에 대해서만 쓰기 작업을 하기 때문에 바로 `member.getGroup()` 을 하면 된다고 판단했습니다.)

그래서 컨트롤러의 API 요청 URL 에서 groupId path variable 을 모두 삭제했습니다.

## Reference
