### PR TITLE
멤버가 그룹에 추가된 순서대로 그룹 조회했을 때 보이도록 변경

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/group/repository/CustomGroupRepositoryImpl.java
+++ b/src/main/java/com/codeit/donggrina/domain/group/repository/CustomGroupRepositoryImpl.java
@@ -7,7 +7,9 @@ import com.codeit.donggrina.domain.group.dto.response.GroupDetailResponse;
 import com.codeit.donggrina.domain.group.entity.Group;
 import com.codeit.donggrina.domain.group.entity.QGroup;
 import com.codeit.donggrina.domain.member.dto.response.MyProfileGetResponse;
+import com.codeit.donggrina.domain.member.entity.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -43,6 +45,7 @@ public class CustomGroupRepositoryImpl implements CustomGroupRepository {
         // MyProfileGetResponse 기반 members 생성
         List<MyProfileGetResponse> members = group.getMembers()
             .stream()
+            .sorted(Comparator.comparing(Member::getJoinGroupAt))
             .map(MyProfileGetResponse::from)
             .collect(Collectors.toList());
 

--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -16,6 +16,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +54,8 @@ public class Member extends Timestamp {
     @JoinColumn(name = "clusters_id", foreignKey = @ForeignKey(name = "fk_clusters_member"))
     private Group group;
 
+    private LocalDateTime joinGroupAt;
+
     @Builder
     private Member(Long id, String username, String name, String role, ProfileImage profileImage,
         String nickname) {
@@ -66,6 +69,7 @@ public class Member extends Timestamp {
 
     public void joinGroup(Group group) {
         this.group = group;
+        this.joinGroupAt = LocalDateTime.now();
     }
 
     public void leaveGroup() {


### PR DESCRIPTION
## Issue Link
close #211 

## To Reviewers
Member 에 새로운 필드(joinGroupAt)를 추가해서 이 필드를 기반으로 그룹을 조회할 때 추가된 순서대로 오름차순으로 보이도록 구현
## Reference
