### PR TITLE
Member 엔티티의 leaveGroup 메소드 호출 시 joinGroupAt 필드의 값을 null 로 변경

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
+++ b/src/main/java/com/codeit/donggrina/domain/member/entity/Member.java
@@ -74,6 +74,7 @@ public class Member extends Timestamp {
 
     public void leaveGroup() {
         this.group = null;
+        this.joinGroupAt = null;
     }
 
     public void updateNickname(String nickname) {


### PR DESCRIPTION
## Issue Link
close #214 

## To Reviewers
그룹에서 멤버가 나갔을 때 멤버의 joinGroupAt 필드를 null 로 바꿔줍니다.
## Reference
