### PR TITLE
외래키에 on delete cascade 옵션 추가

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/codeit/donggrina/domain/calendar/entity/Calendar.java
@@ -5,6 +5,7 @@ import com.codeit.donggrina.domain.calendar.dto.request.CalendarUpdateRequest;
 import com.codeit.donggrina.domain.calendar.util.CalendarCategoryEnumConverter;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.pet.entity.Pet;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -20,6 +21,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -44,6 +47,7 @@ public class Calendar extends Timestamp {
     private LocalDateTime dateTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pet_calendar"))
     private Pet pet;
 

--- a/src/main/java/com/codeit/donggrina/domain/diary/entity/DiaryPet.java
+++ b/src/main/java/com/codeit/donggrina/domain/diary/entity/DiaryPet.java
@@ -13,6 +13,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -29,6 +31,7 @@ public class DiaryPet extends Timestamp {
 
     @ManyToOne
     @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pet_diary_pet"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Pet pet;
 
     @Builder

--- a/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
+++ b/src/main/java/com/codeit/donggrina/domain/growth_history/entity/GrowthHistory.java
@@ -5,25 +5,23 @@ import com.codeit.donggrina.domain.growth_history.dto.request.GrowthHistoryUpdat
 import com.codeit.donggrina.domain.growth_history.util.CategoryEnumConverter;
 import com.codeit.donggrina.domain.member.entity.Member;
 import com.codeit.donggrina.domain.pet.entity.Pet;
-import com.codeit.donggrina.domain.pet.entity.SexValueConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -35,10 +33,11 @@ public class GrowthHistory extends Timestamp {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_member_growth_history" ))
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_member_growth_history"))
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pet_growth_history"))
     private Pet pet;
 


### PR DESCRIPTION
## Issue Link
close #223 
## To Reviewers
일정, 성장기록, 다이어리에서 pet 을 참조하고 있는 외래키 컬럼에 on delete cascade 옵션을 줘서 pet 이 삭제될 때 같이 삭제되도록 했습니다.
## Reference
