### PR TITLE
스토리 조회 시 본인 것인지 구분

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/story/dto/response/StoryFindResponse.java
+++ b/src/main/java/com/codeit/donggrina/domain/story/dto/response/StoryFindResponse.java
@@ -16,6 +16,7 @@ public record StoryFindResponse(
     List<String> images,
     String content,
     LocalDate date,
+    boolean isMyStory,
     boolean favoriteState,
     int favoriteCount,
     List<CommentFindResponse> comments

--- a/src/main/java/com/codeit/donggrina/domain/story/service/StoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/story/service/StoryService.java
@@ -91,6 +91,9 @@ public class StoryService {
                             .commentAuthor(commentAuthor.getName())
                             .comment(child.getContent())
                             .date(child.getDate())
+                            .isMyComment(
+                                commentAuthor.equals(currentMember) || commentAuthor.getGroup()
+                                    .getCreator().equals(currentMember.getUsername()))
                             .build());
                     }
 
@@ -101,6 +104,9 @@ public class StoryService {
                         .commentAuthor(commentAuthor.getName())
                         .comment(comment.getContent())
                         .date(comment.getDate())
+                        .isMyComment(
+                            commentAuthor.equals(currentMember) || commentAuthor.getGroup()
+                                .getCreator().equals(currentMember.getUsername()))
                         .children(children)
                         .build();
                 })
@@ -122,6 +128,8 @@ public class StoryService {
             .images(images)
             .content(foundStory.getContent())
             .date(foundStory.getDate())
+            .isMyStory(foundStory.getMember().equals(currentMember)
+                || foundStory.getGroup().getCreator().equals(currentMember.getUsername()))
             .favoriteState(heartOptional.isPresent())
             .favoriteCount(foundStory.getHeartCount())
             .comments(comments)
@@ -129,6 +137,8 @@ public class StoryService {
     }
 
     public StoryFindListPage findStories(Long memberId, Pageable pageable) {
+        Member currentMember = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
 
         Slice<Diary> page = diaryRepository.findPage(pageable);
         List<StoryFindListResponse> response = page.stream()
@@ -161,7 +171,8 @@ public class StoryService {
                     .commentCount(commentCount)
                     .favoriteCount(diary.getHeartCount())
                     .date(diary.getDate())
-                    .isMyStory(author.getId().equals(memberId))
+                    .isMyStory(author.equals(currentMember)
+                        || author.getGroup().getCreator().equals(currentMember.getUsername()))
                     .build();
             })
             .toList();


### PR DESCRIPTION
## Issue Link
hotfix 입니다.

## To Reviewers
스토리 조회 시 댓글과 스토리가 본인것인지 구분할 수 있도록 데이터를 추가했습니다.

## Reference
