### PR TITLE
스토리 조회 시 이미지 중복 제거

### DIFF
--- a/src/main/java/com/codeit/donggrina/domain/story/service/StoryService.java
+++ b/src/main/java/com/codeit/donggrina/domain/story/service/StoryService.java
@@ -70,6 +70,7 @@ public class StoryService {
 
         List<String> images = foundStory.getDiaryImages().stream()
             .map(DiaryImage::getUrl)
+            .distinct()
             .toList();
 
         Optional<Heart> heartOptional = heartRepository.findByMemberAndDiary(currentMember,
@@ -151,6 +152,7 @@ public class StoryService {
 
                 List<String> images = diary.getDiaryImages().stream()
                     .map(DiaryImage::getUrl)
+                    .distinct()
                     .toList();
 
                 int commentCount = diary.getComments().size();


### PR DESCRIPTION
## Issue Link
hotfix 입니다.

## To Reviewers
스토리 조회 시 이미지가 중복되어 조회되는 것을 제거했습니다.

## Reference
